### PR TITLE
fix : fix des problèmes d'instanciation rapier

### DIFF
--- a/frontend/core/Flipper.js
+++ b/frontend/core/Flipper.js
@@ -2,6 +2,7 @@ import { Scene } from './Scene.js';
 import { Ball } from '../objects/Ball.js';
 import Config from '../physics/Config.js';
 import { GamePhysics } from '../physics/GamePhysics.js';
+import { Wall } from '../objects/Wall.js';
 
 
 async function initFlipper() {
@@ -13,11 +14,58 @@ async function initFlipper() {
     const container = document.getElementById('three');
     container.appendChild(sceneManager.renderer.domElement);
 
+
+    const wallR = new Wall(physics.world, 500, 500, { x: 0, y: 0, z: 200 });
+    const wallL = new Wall(physics.world, 500, 500, { x: 0, y: 0, z: -200 });
+    const wallT = new Wall(physics.world, 500, 500, { x: 500, y: 0, z: 0 });
+    const wallB = new Wall(physics.world, 500, 500, { x: -500, y: 0, z: 0 });
+
+
     const ball = new Ball(physics.world, { x: 0, y: 500, z: 0 });
 
     sceneManager.scene.add(ball.mesh);
+    sceneManager.scene.add(wallR.mesh);
+    sceneManager.scene.add(wallL.mesh);
+    sceneManager.scene.add(wallT.mesh);
+    sceneManager.scene.add(wallB.mesh);
+
+
     sceneManager.startRender(physics, () => ball.syncBall());
 }
 
 // Start the game
 initFlipper();
+
+
+// import { Scene } from './Scene.js';
+// import { Ball } from '../objects/Ball.js';
+// import Config from '../physics/Config.js';
+// import { GamePhysics } from '../physics/GamePhysics.js';
+// import { Wall } from '../objects/Wall.js';
+
+
+// async function initFlipper() {
+//     const physics = new GamePhysics(Config);
+//     await physics.init();
+
+//     const sceneManager = new Scene(physics.world, 500, 500, { x: 0, y: 500, z: 0 });
+
+//     const container = document.getElementById('three');
+//     container.appendChild(sceneManager.renderer.domElement);
+
+//     const mesh = [];
+
+//     mesh.push(new Wall(500, 500, { x: 250, y: 500, z: 0 }));
+//     mesh.push(new Wall(500, 500, { x: -250, y: 500, z: 0 }));
+//     mesh.push(new Wall(500, 500, { x: 0, y: 750, z: 0 }));
+//     mesh.push(new Wall(500, 500, { x: 0, y: 250, z: 0 }));
+
+//     mesh.push(new Ball(physics.world, { x: 0, y: 500, z: 0 }))
+
+//     sceneManager.scene.add(...mesh);
+
+//     sceneManager.startRender(physics, () => mesh[mesh.length - 1].syncBall());
+// }
+
+// // Start the game
+// initFlipper();

--- a/frontend/doc/guide.md
+++ b/frontend/doc/guide.md
@@ -5,7 +5,7 @@
 Le frontend utilise **3 technologies**:
 - **Three.js** → Affiche les objets 3D à l'écran
 - **Rapier** → Simule la physique (gravité, collisions)
-- **JavaScript ES6** → Crée les objets du jeu
+- **JavaScript** → Crée les objets du jeu
 
 ## Comment ça marche?
 

--- a/frontend/objects/Ball.js
+++ b/frontend/objects/Ball.js
@@ -25,7 +25,7 @@ export class Ball {
         // Physics properties - Dynamic rigid body with mass
         const rigidBodyDesc = RAPIER.RigidBodyDesc.dynamic()
             .setTranslation(position.x, position.y, position.z)
-            .setCanSleep(false) // Empêcher la balle de s'endormir
+            .setCanSleep(false)   // Empêcher la balle de s'endormir
             .setCcdEnabled(true); // Continuous Collision Detection (essentiel pour balles rapides)
 
         this.rigidBody = this.world.createRigidBody(rigidBodyDesc);
@@ -33,8 +33,8 @@ export class Ball {
         // Physique précise : friction, restitution, densité
         const colliderDesc = RAPIER.ColliderDesc.ball(this.radius)
             .setDensity(Config.ball.density)               // Densité élevée (acier)
-            .setRestitution(Config.ball.restitution)           // Rebond
-            .setFriction(Config.ball.friction);             // Glissement
+            .setRestitution(Config.ball.restitution)       // Rebond
+            .setFriction(Config.ball.friction);            // Glissement
 
         this.world.createCollider(colliderDesc, this.rigidBody);
     }


### PR DESCRIPTION
Le problème d'instanciation rapier était dû à la mauvaise instanciation des objets wall qui nécessitaient de passer en paramètre la physique du monde

(PS: Un bout de code à été ajouté en commentaire pour tester une autre instanciation des objets dans le fichier Flipper.js à partir d'une autre issue. Prière de ne pas le supprimer et de le laisser en commentaire)