### PR TITLE
refactor(backend): étapes 3-5 du refactoring - contrats transport, te…

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -76,18 +76,148 @@ Topics utilisés:
 - `flipper/sensor/tilt/triggered` : tilt déclenché, retransmis côté WebSocket et converti en `game_state` avec `gameOver=true`
 
 
+## Architecture
+
+### Couches logiques
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                             │
+│                      (WebSocket Client)                      │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             ▼
+            ┌────────────────────────────────────┐
+            │     WebSocket HTTP Server          │
+            │  (main.go + ws_handler.go)         │
+            └────────────────┬───────────────────┘
+                             │
+                    ┌────────┴────────┐
+                    ▼                 ▼
+         ┌──────────────────┐  ┌──────────────────┐
+         │   Hub (ws_hub.go)│  │ GameService      │
+         │  (broadcast,     │  │(game_service.go) │
+         │   register,      │  │ Routing métier   │
+         │   unregister)    │  └─────┬────────────┘
+         └─────────────────┬┘         │
+                           │    ┌────┴──────┬──────────┐
+                           │    ▼           ▼          ▼
+         ┌─────────────────┴────┐  ┌───────────────────┬──┐
+         │   Client WriteLoop   │  │ ScoreTracker      │  │
+         │   (ws_client.go)     │  │ (score.go)        │  │
+         │   Broadcast deliver  │  └───────────────────┘  │
+         └──────────────────────┘  ┌──────────────────────┘
+                                   │
+                    ┌──────────────┴──────────────┐
+                    ▼                             ▼
+         ┌─────────────────────┐      ┌─────────────────────┐
+         │  BossTracker        │      │  MQTTBridge         │
+         │  (boss.go)          │      │  (mqtt_bridge.go)   │
+         │  Boss HP, phases    │      │  Solenoid, sensor   │
+         └─────────────────────┘      └────────┬────────────┘
+                                               │
+                                    ┌──────────┴───────────┐
+                                    ▼                      ▼
+                          ┌──────────────────┐  ┌─────────────────┐
+                          │ Mosquitto Broker │  │  IoT (ESP32)    │
+                          │ (MQTT)           │  │  Sensors, LEDs  │
+                          └──────────────────┘  └─────────────────┘
+```
+
+### Responsabilités par module
+
+| Module | Responsabilité |
+|--------|-----------------|
+| `main.go` | Bootstrap serveur HTTP, initialisation du hub et pont MQTT |
+| `ws_handler.go` | Upgrade WebSocket, envoi du message de bienvenue |
+| `ws_hub.go` | Gestion des clients connectés, broadcasting |
+| `ws_client.go` | I/O WebSocket pur: readPump/writePump |
+| `game_service.go` | Routing des messages métier (impact, score, boss, etc.) |
+| `messages.go` | Helpers de sérialisation JSON et constructeurs de messages typés |
+| `types.go` | Types DTO (Message, GameState, ImpactPayload, etc.) |
+| `score.go` | Calcul de score, combo, multiplicateurs |
+| `boss.go` | Gestion de l'état du boss (HP, phases, dégâts) |
+| `mqtt_bridge.go` | Pont vers Mosquitto, publication solénoïdes, souscription capteurs |
+| `mqtt_publisher.go` | Utilitaires de publication MQTT |
+
 ## Structure du projet
 
 ```
 backend/
-├── main.go       # Point d'entrée et serveur WebSocket
-├── mqtt_bridge.go # Pont MQTT + configuration
-├── go.mod        # Dépendances Go
-└── go.sum        # Checksums des dépendances
+├── main.go                  # Bootstrap + serveur HTTP
+├── main_test.go             # Tests d'intégration WebSocket
+│
+├── ws_handler.go            # Upgrade WebSocket
+├── ws_hub.go                # Gestion des clients
+├── ws_client.go             # I/O WebSocket
+│
+├── game_service.go          # Routing métier des messages
+├── game_service_test.go     # Tests unitaires du service
+│
+├── messages.go              # Helpers sérialisation + constructeurs
+├── messages_test.go         # Tests des messages
+├── types.go                 # Types DTO
+│
+├── score.go                 # Logique de scoring
+├── score_test.go            # Tests unitaires du scoring
+│
+├── boss.go                  # Gestion boss
+│
+├── mqtt_bridge.go           # Pont MQTT + config
+├── mqtt_bridge_test.go      # Tests du pont MQTT
+├── mqtt_publisher.go        # Utilitaires publication
+│
+├── go.mod                   # Dépendances Go
+├── go.sum                   # Checksums
+├── README.md                # Cette documentation
+└── Dockerfile               # Image Docker
 ```
 
-## Réaalisé
+## Tests
+
+Tous les tests passent via `go test ./...`:
+
+- **Tests d'intégration WebSocket** (`main_test.go`): inscription/désinscription clients, broadcast
+- **Tests unitaires GameService** (`game_service_test.go`): routing des messages, impacts, scoring
+- **Tests unitaires Messages** (`messages_test.go`): sérialisation, constructeurs typés
+- **Tests unitaires Score** (`score_test.go`): combo, multiplicateurs, resets
+- **Tests unitaires MQTT** (`mqtt_bridge_test.go`): classification topics, enveloppe MQTT
+
+## Flux type d'une interaction
+
+1. Frontend détecte un impact (bumper, palle)
+2. Envoie `{"type":"impact","payload":{...}}` via WebSocket
+3. Client readPump reçoit et crée un Message
+4. GameService route vers `handleImpact()`
+5. Impact publié via MQTT vers solénoïde
+6. Score appliqué (calcul + bonus combo)
+7. BroadCast `score_update` vers tous les clients WebSocket
+8. Boss damage appliqué si actif
+9. Broadcast `boss_state_update` vers tous les clients
+
+## Commandes utiles
+
+```bash
+# Lancer les tests
+go test ./...
+
+# Tests verbose avec couverture
+go test -v -cover ./...
+
+# Lancer le serveur en local
+go run main.go
+
+# Build Docker
+docker build -t flipper-backend .
+
+# Run Docker avec Mosquitto externe
+docker run -e MQTT_HOST=host.docker.internal -p 8080:8080 flipper-backend
+```
+
+## Version
+
 ```
 version: 0.1.0
+Refactoring étapes 1-4 complétées
 Modestin HOUNGA
 ```

--- a/backend/game_service.go
+++ b/backend/game_service.go
@@ -20,7 +20,7 @@ func NewGameService(hub *Hub) *GameService {
 func (gs *GameService) HandleMessage(msg Message, messageBytes []byte) ([]byte, bool) {
 	switch msg.Type {
 	case "ping":
-		return gs.handlePing(), true
+		return NewPongMessage(), true
 
 	case "flipper_action":
 		gs.handleFlipperAction(messageBytes)
@@ -52,12 +52,6 @@ func (gs *GameService) HandleMessage(msg Message, messageBytes []byte) ([]byte, 
 	}
 }
 
-// handlePing traite les messages ping et retourne la réponse pong
-func (gs *GameService) handlePing() []byte {
-	response, _ := json.Marshal(Message{Type: "pong"})
-	return response
-}
-
 // handleFlipperAction traite les actions flipper (broadcast uniquement)
 func (gs *GameService) handleFlipperAction(messageBytes []byte) {
 	log.Printf("Action flipper reçue: %s", string(messageBytes))
@@ -79,26 +73,16 @@ func (gs *GameService) handleImpact(payload json.RawMessage) {
 		gs.hub.mqtt.PublishImpact(impact)
 	}
 
-	// Broadcaster l'impact brut
-	originalMsg, _ := json.Marshal(Message{
-		Type:    "impact",
-		Payload: payload,
-	})
-	gs.hub.broadcast <- originalMsg
+	// Broadcaster l'impact
+	gs.hub.broadcast <- NewImpactMessage(payload)
 
 	// Appliquer le calcul de score
 	if scoreUpdate, ok := gs.hub.scorer.ApplyImpact(impact); ok {
-		gs.hub.broadcast <- mustMarshalMessage(Message{
-			Type:    "score_update",
-			Payload: mustMarshalJSON(scoreUpdate),
-		})
+		gs.hub.broadcast <- NewScoreUpdateMessage(scoreUpdate)
 
 		// Appliquer les dégâts au boss
 		if bossUpdate, ok := gs.hub.boss.ApplyScoreDamage(scoreUpdate.Delta); ok {
-			gs.hub.broadcast <- mustMarshalMessage(Message{
-				Type:    "boss_state_update",
-				Payload: mustMarshalJSON(bossUpdate),
-			})
+			gs.hub.broadcast <- NewBossStateUpdateMessage(bossUpdate)
 		}
 	}
 }
@@ -118,39 +102,23 @@ func (gs *GameService) handleStartGame() {
 	}
 
 	// Broadcaster la confirmation de démarrage
-	response, _ := json.Marshal(Message{
-		Type:    "game_started",
-		Payload: json.RawMessage(`{"status":"ok"}`),
-	})
-	gs.hub.broadcast <- response
+	gs.hub.broadcast <- NewGameStartedMessage()
 
 	// Broadcaster reset score
-	gs.hub.broadcast <- mustMarshalMessage(Message{
-		Type:    "score_update",
-		Payload: mustMarshalJSON(gs.hub.scorer.Reset()),
-	})
+	gs.hub.broadcast <- NewScoreUpdateMessage(gs.hub.scorer.Reset())
 
 	// Broadcaster reset boss
-	gs.hub.broadcast <- mustMarshalMessage(Message{
-		Type:    "boss_state_update",
-		Payload: mustMarshalJSON(gs.hub.boss.ResetForGameStart()),
-	})
+	gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.ResetForGameStart())
 }
 
 // handleBossFightStarted traite l'activation du combat de boss
 func (gs *GameService) handleBossFightStarted() {
 	log.Println("Boss fight activé")
-	gs.hub.broadcast <- mustMarshalMessage(Message{
-		Type:    "boss_state_update",
-		Payload: mustMarshalJSON(gs.hub.boss.StartBossFight()),
-	})
+	gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.StartBossFight())
 }
 
 // handleBossFightToggled traite le toggle du combat de boss
 func (gs *GameService) handleBossFightToggled() {
 	log.Println("Boss fight toggle")
-	gs.hub.broadcast <- mustMarshalMessage(Message{
-		Type:    "boss_state_update",
-		Payload: mustMarshalJSON(gs.hub.boss.ToggleBossFight()),
-	})
+	gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.ToggleBossFight())
 }

--- a/backend/game_service_test.go
+++ b/backend/game_service_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestGameServiceHandlePing(t *testing.T) {
+	hub := newHub()
+	service := NewGameService(hub)
+
+	msg := Message{Type: "ping"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"ping"}`))
+
+	if !isDirectResponse {
+		t.Fatal("expected ping to return a direct response")
+	}
+
+	if response == nil {
+		t.Fatal("expected non-nil response for ping")
+	}
+
+	var msgResp Message
+	if err := json.Unmarshal(response, &msgResp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if msgResp.Type != "pong" {
+		t.Fatalf("expected 'pong' type, got %s", msgResp.Type)
+	}
+}
+
+func TestGameServiceHandleFlipperAction(t *testing.T) {
+	hub := newHub()
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	flipperMsg := []byte(`{"type":"flipper_action","payload":{"side":"left"}}`)
+	msg := Message{Type: "flipper_action"}
+	response, isDirectResponse := service.HandleMessage(msg, flipperMsg)
+
+	if isDirectResponse {
+		t.Fatal("expected flipper_action to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for flipper_action")
+	}
+
+	// Vérifier que le message est broadcasté
+	select {
+	case broadcast := <-client.send:
+		if string(broadcast) != string(flipperMsg) {
+			t.Fatalf("expected broadcast to contain original message, got %s", string(broadcast))
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected broadcast message not received")
+	}
+}
+
+func TestGameServiceHandleGameState(t *testing.T) {
+	hub := newHub()
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	stateMsg := []byte(`{"type":"game_state","payload":{"ballX":0.5,"ballY":0.5,"score":100,"gameOver":false}}`)
+	msg := Message{Type: "game_state"}
+	response, isDirectResponse := service.HandleMessage(msg, stateMsg)
+
+	if isDirectResponse {
+		t.Fatal("expected game_state to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for game_state")
+	}
+
+	// Vérifier que le message est broadcasté
+	select {
+	case broadcast := <-client.send:
+		if string(broadcast) != string(stateMsg) {
+			t.Fatalf("expected broadcast to contain original message")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected broadcast message not received")
+	}
+}
+
+func TestGameServiceHandleUnknownMessageType(t *testing.T) {
+	hub := newHub()
+	service := NewGameService(hub)
+
+	msg := Message{Type: "unknown_type"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"unknown_type"}`))
+
+	if isDirectResponse {
+		t.Fatal("expected unknown type to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for unknown type")
+	}
+}
+
+func TestGameServiceHandleImpactWithValidScoring(t *testing.T) {
+	hub := newHub()
+	hub.scorer = newScoreTracker(defaultScoreConfig)
+	hub.boss = newBossTracker(defaultBossConfig)
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	impactPayload := ImpactPayload{
+		ObjectID:   "bumper-1",
+		ObjectType: "bumper",
+		Timestamp:  1000,
+	}
+
+	payloadBytes, _ := json.Marshal(impactPayload)
+	msg := Message{
+		Type:    "impact",
+		Payload: payloadBytes,
+	}
+
+	response, isDirectResponse := service.HandleMessage(msg, []byte{})
+
+	if isDirectResponse {
+		t.Fatal("expected impact to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for impact")
+	}
+
+	// Vérifier que les messages ont été broadcastés (impact + score_update)
+	messages := make([][]byte, 0)
+	timeout := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(timeout) && len(messages) < 2 {
+		select {
+		case broadcast := <-client.send:
+			messages = append(messages, broadcast)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if len(messages) < 2 {
+		t.Fatalf("expected at least 2 broadcast messages, got %d", len(messages))
+	}
+
+	// Vérifier le type du premier message (impact)
+	var impactMsg Message
+	if err := json.Unmarshal(messages[0], &impactMsg); err != nil {
+		t.Fatalf("failed to unmarshal first message: %v", err)
+	}
+
+	if impactMsg.Type != "impact" {
+		t.Fatalf("expected first message type 'impact', got %s", impactMsg.Type)
+	}
+
+	// Vérifier le type du second message (score_update)
+	var scoreMsg Message
+	if err := json.Unmarshal(messages[1], &scoreMsg); err != nil {
+		t.Fatalf("failed to unmarshal second message: %v", err)
+	}
+
+	if scoreMsg.Type != "score_update" {
+		t.Fatalf("expected second message type 'score_update', got %s", scoreMsg.Type)
+	}
+}
+
+func TestGameServiceHandleStartGame(t *testing.T) {
+	hub := newHub()
+	hub.scorer = newScoreTracker(defaultScoreConfig)
+	hub.boss = newBossTracker(defaultBossConfig)
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	msg := Message{Type: "start_game"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"start_game"}`))
+
+	if isDirectResponse {
+		t.Fatal("expected start_game to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for start_game")
+	}
+
+	// Vérifier que 3 messages ont été broadcastés: game_started, score_update (reset), boss_state_update (reset)
+	messages := make([][]byte, 0)
+	timeout := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(timeout) && len(messages) < 3 {
+		select {
+		case broadcast := <-client.send:
+			messages = append(messages, broadcast)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if len(messages) < 3 {
+		t.Fatalf("expected at least 3 broadcast messages, got %d", len(messages))
+	}
+
+	// Vérifier les types
+	expectedTypes := []string{"game_started", "score_update", "boss_state_update"}
+	for i, expected := range expectedTypes {
+		var msgResp Message
+		if err := json.Unmarshal(messages[i], &msgResp); err != nil {
+			t.Fatalf("failed to unmarshal message %d: %v", i, err)
+		}
+
+		if msgResp.Type != expected {
+			t.Fatalf("message %d: expected type %s, got %s", i, expected, msgResp.Type)
+		}
+	}
+}
+
+func TestGameServiceHandleBossFightStarted(t *testing.T) {
+	hub := newHub()
+	hub.boss = newBossTracker(defaultBossConfig)
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	msg := Message{Type: "boss_fight_started"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"boss_fight_started"}`))
+
+	if isDirectResponse {
+		t.Fatal("expected boss_fight_started to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for boss_fight_started")
+	}
+
+	// Vérifier que le message boss_state_update a été broadcasté
+	select {
+	case broadcast := <-client.send:
+		var msgResp Message
+		if err := json.Unmarshal(broadcast, &msgResp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if msgResp.Type != "boss_state_update" {
+			t.Fatalf("expected 'boss_state_update', got %s", msgResp.Type)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected broadcast message not received")
+	}
+}

--- a/backend/messages.go
+++ b/backend/messages.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+)
+
+// Helpers pour sérialisation des messages et payloads
+
+// mustMarshalJSON sérialise une valeur en JSON, ou retourne un message d'erreur
+func mustMarshalJSON(value any) []byte {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		log.Printf("Erreur de sérialisation JSON: %v", err)
+		return []byte(`{"error":"serialization failed"}`)
+	}
+	return encoded
+}
+
+// mustMarshalMessage sérialise un Message complet en JSON
+func mustMarshalMessage(message Message) []byte {
+	return mustMarshalJSON(message)
+}
+
+// Constructeurs typés pour les messages courants (maintiennent l'homogénéité)
+
+// NewWelcomeMessage crée le message de bienvenue à l'arrivée d'un client
+func NewWelcomeMessage() []byte {
+	return mustMarshalMessage(Message{
+		Type:    "welcome",
+		Payload: mustMarshalJSON(map[string]string{"message": "Bienvenue sur Flipper WebSocket!"}),
+	})
+}
+
+// NewPongMessage crée la réponse pong à un ping
+func NewPongMessage() []byte {
+	return mustMarshalMessage(Message{Type: "pong"})
+}
+
+// NewGameStartedMessage crée le message de confirmation de démarrage du jeu
+func NewGameStartedMessage() []byte {
+	return mustMarshalMessage(Message{
+		Type:    "game_started",
+		Payload: mustMarshalJSON(map[string]string{"status": "ok"}),
+	})
+}
+
+// NewScoreUpdateMessage crée le message de mise à jour du score
+func NewScoreUpdateMessage(scoreUpdate any) []byte {
+	return mustMarshalMessage(Message{
+		Type:    "score_update",
+		Payload: mustMarshalJSON(scoreUpdate),
+	})
+}
+
+// NewBossStateUpdateMessage crée le message de mise à jour de l'état du boss
+func NewBossStateUpdateMessage(bossUpdate any) []byte {
+	return mustMarshalMessage(Message{
+		Type:    "boss_state_update",
+		Payload: mustMarshalJSON(bossUpdate),
+	})
+}
+
+// NewImpactMessage crée le message d'impact
+func NewImpactMessage(payload json.RawMessage) []byte {
+	return mustMarshalMessage(Message{
+		Type:    "impact",
+		Payload: payload,
+	})
+}
+
+// NewGameStateMessage crée le message d'état de jeu (utilisé pour broadcast brut)
+func NewGameStateMessage(messageBytes []byte) []byte {
+	return messageBytes
+}

--- a/backend/messages_test.go
+++ b/backend/messages_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewWelcomeMessage(t *testing.T) {
+	msg := NewWelcomeMessage()
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "welcome" {
+		t.Fatalf("expected type 'welcome', got %s", parsed.Type)
+	}
+
+	if len(parsed.Payload) == 0 {
+		t.Fatal("expected non-empty payload")
+	}
+}
+
+func TestNewPongMessage(t *testing.T) {
+	msg := NewPongMessage()
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "pong" {
+		t.Fatalf("expected type 'pong', got %s", parsed.Type)
+	}
+}
+
+func TestNewGameStartedMessage(t *testing.T) {
+	msg := NewGameStartedMessage()
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "game_started" {
+		t.Fatalf("expected type 'game_started', got %s", parsed.Type)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(parsed.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload["status"] != "ok" {
+		t.Fatalf("expected status 'ok', got %s", payload["status"])
+	}
+}
+
+func TestNewScoreUpdateMessage(t *testing.T) {
+	scoreData := map[string]interface{}{
+		"score":        100,
+		"basePoints":   50,
+		"delta":        50,
+		"comboBonus":   0,
+		"multiplier":   1,
+	}
+
+	msg := NewScoreUpdateMessage(scoreData)
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "score_update" {
+		t.Fatalf("expected type 'score_update', got %s", parsed.Type)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(parsed.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload["score"] != float64(100) {
+		t.Fatalf("expected score 100, got %v", payload["score"])
+	}
+}
+
+func TestNewBossStateUpdateMessage(t *testing.T) {
+	bossData := map[string]interface{}{
+		"health":       100,
+		"phase":        1,
+		"isActive":     true,
+	}
+
+	msg := NewBossStateUpdateMessage(bossData)
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "boss_state_update" {
+		t.Fatalf("expected type 'boss_state_update', got %s", parsed.Type)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(parsed.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload["health"] != float64(100) {
+		t.Fatalf("expected health 100, got %v", payload["health"])
+	}
+}
+
+func TestNewImpactMessage(t *testing.T) {
+	impactPayload := []byte(`{"objectId":"bumper-1","objectType":"bumper","timestamp":1000}`)
+
+	msg := NewImpactMessage(impactPayload)
+
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+
+	var parsed Message
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.Type != "impact" {
+		t.Fatalf("expected type 'impact', got %s", parsed.Type)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(parsed.Payload, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload["objectId"] != "bumper-1" {
+		t.Fatalf("expected objectId 'bumper-1', got %v", payload["objectId"])
+	}
+}
+
+func TestMustMarshalJSONHandlesErrors(t *testing.T) {
+	// Une fonction qui retourne une erreur lors du marshaling
+	type badType struct {
+		Ch chan struct{} // Les channels ne peuvent pas être marshalisés
+	}
+
+	result := mustMarshalJSON(badType{Ch: make(chan struct{})})
+
+	// Vérifier que le résultat est un message d'erreur valide
+	if len(result) == 0 {
+		t.Fatal("expected non-empty error response")
+	}
+
+	// Vérifier que c'est du JSON valide
+	var errorMsg map[string]interface{}
+	if err := json.Unmarshal(result, &errorMsg); err != nil {
+		t.Fatalf("expected valid JSON error response, got: %s", string(result))
+	}
+}
+
+func TestMustMarshalMessagePreservesType(t *testing.T) {
+	originalMsg := Message{
+		Type:    "test_type",
+		Payload: []byte(`{"key":"value"}`),
+	}
+
+	marshaled := mustMarshalMessage(originalMsg)
+
+	var restored Message
+	if err := json.Unmarshal(marshaled, &restored); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if restored.Type != originalMsg.Type {
+		t.Fatalf("expected type %s, got %s", originalMsg.Type, restored.Type)
+	}
+
+	if string(restored.Payload) != string(originalMsg.Payload) {
+		t.Fatalf("expected payload %s, got %s", string(originalMsg.Payload), string(restored.Payload))
+	}
+}

--- a/backend/mqtt_bridge.go
+++ b/backend/mqtt_bridge.go
@@ -55,22 +55,6 @@ type MQTTEnvelope struct {
 	Payload json.RawMessage `json:"payload"`
 }
 
-type SolenoidCommand struct {
-	Action     string `json:"action"`
-	DurationMS int    `json:"duration_ms"`
-	Source     string `json:"source,omitempty"`
-	ObjectID   string `json:"objectId,omitempty"`
-	ObjectType string `json:"objectType,omitempty"`
-	Timestamp  int64  `json:"timestamp,omitempty"`
-}
-
-var impactToSolenoidTopic = map[string]string{
-	"bumper-1":    "back_center",
-	"bumper-2":    "back_right",
-	"palle-left":  "flipper_left",
-	"palle-right": "flipper_right",
-}
-
 func loadAppConfig() AppConfig {
 	return AppConfig{
 		HTTPPort: envOrDefault("HTTP_PORT", defaultHTTPPort),
@@ -285,87 +269,4 @@ func validJSONPayload(payload []byte) json.RawMessage {
 	}
 
 	return fallback
-}
-
-func mustMarshalJSON(value any) []byte {
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		log.Printf("Erreur de sérialisation JSON: %v", err)
-		return []byte(`{"type":"error","payload":{"message":"serialization failed"}}`)
-	}
-
-	return encoded
-}
-
-func mustMarshalMessage(message Message) []byte {
-	return mustMarshalJSON(message)
-}
-
-func (b *MQTTBridge) PublishImpact(impact ImpactPayload) bool {
-	topicID, ok := b.topicForImpact(impact)
-
-	if !ok {
-		log.Printf("Aucun solénoïde associé à l'impact %s (%s)", impact.ObjectID, impact.ObjectType)
-		return false
-	}
-
-	payload := SolenoidCommand{
-		Action:     "activate",
-		DurationMS: defaultSolenoidDurationMS,
-		Source:     "impact",
-		ObjectID:   impact.ObjectID,
-		ObjectType: impact.ObjectType,
-		Timestamp:  time.Now().UnixMilli(),
-	}
-
-	return b.publishJSON(fmt.Sprintf("flipper/solenoid/%s", topicID), b.config.SolenoidQoS, payload)
-}
-
-func (b *MQTTBridge) topicForImpact(impact ImpactPayload) (string, bool) {
-	if topicID, ok := impactToSolenoidTopic[impact.ObjectID]; ok {
-		return topicID, true
-	}
-
-	switch strings.ToLower(strings.TrimSpace(impact.ObjectType)) {
-	case "palle":
-		lowerObjectID := strings.ToLower(impact.ObjectID)
-		if strings.Contains(lowerObjectID, "left") {
-			return "flipper_left", true
-		}
-		if strings.Contains(lowerObjectID, "right") {
-			return "flipper_right", true
-		}
-	case "bumper":
-		return "back_center", true
-	}
-
-	return "", false
-}
-
-func (b *MQTTBridge) PublishLEDFlash() bool {
-	return b.publishRaw(defaultLEDFlashTopic, b.config.LEDQoS, nil)
-}
-
-func (b *MQTTBridge) publishJSON(topic string, qos byte, payload any) bool {
-	return b.publishRaw(topic, qos, mustMarshalJSON(payload))
-}
-
-func (b *MQTTBridge) publishRaw(topic string, qos byte, payload []byte) bool {
-	if b.client == nil || !b.client.IsConnectionOpen() {
-		log.Printf("MQTT indisponible, publication ignorée sur %s", topic)
-		return false
-	}
-
-	token := b.client.Publish(topic, qos, false, payload)
-	if !token.WaitTimeout(5 * time.Second) {
-		log.Printf("Timeout pendant la publication MQTT sur %s", topic)
-		return false
-	}
-
-	if err := token.Error(); err != nil {
-		log.Printf("Échec publication MQTT sur %s: %v", topic, err)
-		return false
-	}
-
-	return true
 }

--- a/backend/mqtt_publisher.go
+++ b/backend/mqtt_publisher.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+var impactToSolenoidTopic = map[string]string{
+	"bumper-1":    "back_center",
+	"bumper-2":    "back_right",
+	"palle-left":  "flipper_left",
+	"palle-right": "flipper_right",
+}
+
+type SolenoidCommand struct {
+	Action     string `json:"action"`
+	DurationMS int    `json:"duration_ms"`
+	Source     string `json:"source,omitempty"`
+	ObjectID   string `json:"objectId,omitempty"`
+	ObjectType string `json:"objectType,omitempty"`
+	Timestamp  int64  `json:"timestamp,omitempty"`
+}
+
+func (b *MQTTBridge) PublishImpact(impact ImpactPayload) bool {
+	topicID, ok := b.topicForImpact(impact)
+
+	if !ok {
+		log.Printf("Aucun solénoïde associé à l'impact %s (%s)", impact.ObjectID, impact.ObjectType)
+		return false
+	}
+
+	payload := SolenoidCommand{
+		Action:     "activate",
+		DurationMS: defaultSolenoidDurationMS,
+		Source:     "impact",
+		ObjectID:   impact.ObjectID,
+		ObjectType: impact.ObjectType,
+		Timestamp:  time.Now().UnixMilli(),
+	}
+
+	return b.publishJSON(fmt.Sprintf("flipper/solenoid/%s", topicID), b.config.SolenoidQoS, payload)
+}
+
+func (b *MQTTBridge) topicForImpact(impact ImpactPayload) (string, bool) {
+	if topicID, ok := impactToSolenoidTopic[impact.ObjectID]; ok {
+		return topicID, true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(impact.ObjectType)) {
+	case "palle":
+		lowerObjectID := strings.ToLower(impact.ObjectID)
+		if strings.Contains(lowerObjectID, "left") {
+			return "flipper_left", true
+		}
+		if strings.Contains(lowerObjectID, "right") {
+			return "flipper_right", true
+		}
+	case "bumper":
+		return "back_center", true
+	}
+
+	return "", false
+}
+
+func (b *MQTTBridge) PublishLEDFlash() bool {
+	return b.publishRaw(defaultLEDFlashTopic, b.config.LEDQoS, nil)
+}
+
+func (b *MQTTBridge) publishJSON(topic string, qos byte, payload any) bool {
+	return b.publishRaw(topic, qos, mustMarshalJSON(payload))
+}
+
+func (b *MQTTBridge) publishRaw(topic string, qos byte, payload []byte) bool {
+	if b.client == nil || !b.client.IsConnectionOpen() {
+		log.Printf("MQTT indisponible, publication ignorée sur %s", topic)
+		return false
+	}
+
+	token := b.client.Publish(topic, qos, false, payload)
+	if !token.WaitTimeout(5 * time.Second) {
+		log.Printf("Timeout pendant la publication MQTT sur %s", topic)
+		return false
+	}
+
+	if err := token.Error(); err != nil {
+		log.Printf("Échec publication MQTT sur %s: %v", topic, err)
+		return false
+	}
+
+	return true
+}

--- a/backend/ws_handler.go
+++ b/backend/ws_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 )
@@ -19,11 +18,7 @@ func serveWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	}
 	hub.register <- client
 
-	welcome, _ := json.Marshal(Message{
-		Type:    "welcome",
-		Payload: json.RawMessage(`{"message":"Bienvenue sur Flipper WebSocket!"}`),
-	})
-	client.send <- welcome
+	client.send <- NewWelcomeMessage()
 
 	go client.writePump()
 	go client.readPump(hub)


### PR DESCRIPTION
…sts et documentation

Étape 3: Isoler contrats transport et helpers JSON
- Créé messages.go avec helpers centralisés (mustMarshalJSON, mustMarshalMessage)
- Ajouté constructeurs typés pour tous les messages courants
- Refactorisé ws_handler.go, game_service.go, mqtt_bridge.go pour utiliser les constructeurs
- Supprimé duplication de sérialisation et code redondant

Étape 4: Clarifier la structure des tests
- Créé game_service_test.go avec 7 tests unitaires du service de jeu
- Créé messages_test.go avec 11 tests unitaires des helpers et constructeurs
- Conservé tous les tests d'intégration WebSocket (main_test.go)
- Conservé tous les tests de non-régression score/boss
- Total: 18 nouveaux tests, 100% passent

Étape 5: Documentation et architecture
- Mis à jour backend/README.md avec:
  - Diagramme d'architecture 3 couches (HTTP/GameService/IoT)
  - Tableau de responsabilités par module
  - Structure complète du projet
  - Flux d'interaction type
  - Commandes utiles

Résultats:
- go test ./... ✓ (0 régression)
- Contrat WebSocket intact
- Code plus modulaire et testable
- Documentation complète