### PR TITLE
Gameplay : ajout du player state et des vies pour le boss fight

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,9 +57,13 @@ Variables utiles:
 | `start_game` | Client → Serveur | Démarrer une nouvelle partie |
 | `boss_fight_started` | Client → Serveur | Activer explicitement le boss fight |
 | `boss_fight_toggled` | Client → Serveur | Basculer le boss fight entre actif et inactif |
+| `boss_attack_test` | Client → Serveur | Simuler une attaque moyenne du boss sur le joueur |
+| `player_damage_test` | Client → Serveur | Simuler des dégâts joueur pour les tests |
+| `ball_lost` | Client → Serveur | Simuler une perte de balle |
 | `game_started` | Serveur → Client | Confirmation du démarrage |
 | `score_update` | Serveur → Client | Nouveau score calculé avec delta et combo courant |
 | `boss_state_update` | Serveur → Client | État courant du boss (HP, activation, dégâts) |
+| `player_state_update` | Serveur → Client | État courant du joueur (HP, balles, game over) |
 | `flipper_action` | Client → Serveur | Action sur les flippers (left/right) |
 | `impact` | Client → Serveur | Contact détecté côté frontend (bumper, palle, mur, rampe) |
 | `game_state` | Bidirectionnel | État actuel du jeu |
@@ -137,6 +141,7 @@ Topics utilisés:
 | `types.go` | Types DTO (Message, GameState, ImpactPayload, etc.) |
 | `score.go` | Calcul de score, combo, multiplicateurs |
 | `boss.go` | Gestion de l'état du boss (HP, phases, dégâts) |
+| `player.go` | Gestion de l'état du joueur (HP, balles, game over) |
 | `mqtt_bridge.go` | Pont vers Mosquitto, publication solénoïdes, souscription capteurs |
 | `mqtt_publisher.go` | Utilitaires de publication MQTT |
 
@@ -162,6 +167,7 @@ backend/
 ├── score_test.go            # Tests unitaires du scoring
 │
 ├── boss.go                  # Gestion boss
+├── player.go                # Gestion joueur
 │
 ├── mqtt_bridge.go           # Pont MQTT + config
 ├── mqtt_bridge_test.go      # Tests du pont MQTT
@@ -181,6 +187,7 @@ Tous les tests passent via `go test ./...`:
 - **Tests unitaires GameService** (`game_service_test.go`): routing des messages, impacts, scoring
 - **Tests unitaires Messages** (`messages_test.go`): sérialisation, constructeurs typés
 - **Tests unitaires Score** (`score_test.go`): combo, multiplicateurs, resets
+- **Tests unitaires Player** (`player_test.go`): HP joueur, perte de balle, game over
 - **Tests unitaires MQTT** (`mqtt_bridge_test.go`): classification topics, enveloppe MQTT
 
 ## Flux type d'une interaction
@@ -194,6 +201,8 @@ Tous les tests passent via `go test ./...`:
 7. BroadCast `score_update` vers tous les clients WebSocket
 8. Boss damage appliqué si actif
 9. Broadcast `boss_state_update` vers tous les clients
+
+Au démarrage d'une partie, le backend réinitialise aussi l'état joueur et diffuse `player_state_update`.
 
 ## Commandes utiles
 

--- a/backend/game_service.go
+++ b/backend/game_service.go
@@ -46,6 +46,14 @@ func (gs *GameService) HandleMessage(msg Message, messageBytes []byte) ([]byte, 
 		gs.handleBossFightToggled()
 		return nil, false
 
+	case "boss_attack_test", "player_damage_test":
+		gs.handlePlayerDamageTest()
+		return nil, false
+
+	case "ball_lost":
+		gs.handleBallLost()
+		return nil, false
+
 	default:
 		log.Printf("Type de message inconnu: %s", msg.Type)
 		return nil, false
@@ -109,6 +117,9 @@ func (gs *GameService) handleStartGame() {
 
 	// Broadcaster reset boss
 	gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.ResetForGameStart())
+
+	// Broadcaster reset joueur
+	gs.hub.broadcast <- NewPlayerStateUpdateMessage(gs.hub.player.ResetForGameStart())
 }
 
 // handleBossFightStarted traite l'activation du combat de boss
@@ -121,4 +132,16 @@ func (gs *GameService) handleBossFightStarted() {
 func (gs *GameService) handleBossFightToggled() {
 	log.Println("Boss fight toggle")
 	gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.ToggleBossFight())
+}
+
+// handlePlayerDamageTest simule une attaque du boss tant que les vraies attaques ne sont pas branchées
+func (gs *GameService) handlePlayerDamageTest() {
+	log.Println("Dégâts joueur test")
+	gs.hub.broadcast <- NewPlayerStateUpdateMessage(gs.hub.player.ApplyDamage(defaultBossAttackDamage))
+}
+
+// handleBallLost simule une perte de balle
+func (gs *GameService) handleBallLost() {
+	log.Println("Perte de balle")
+	gs.hub.broadcast <- NewPlayerStateUpdateMessage(gs.hub.player.LoseBall())
 }

--- a/backend/game_service_test.go
+++ b/backend/game_service_test.go
@@ -115,6 +115,7 @@ func TestGameServiceHandleImpactWithValidScoring(t *testing.T) {
 	hub := newHub()
 	hub.scorer = newScoreTracker(defaultScoreConfig)
 	hub.boss = newBossTracker(defaultBossConfig)
+	hub.player = newPlayerTracker(defaultPlayerConfig)
 	go hub.run()
 
 	client := &Client{send: make(chan []byte, 256)}
@@ -202,10 +203,10 @@ func TestGameServiceHandleStartGame(t *testing.T) {
 		t.Fatal("expected nil response for start_game")
 	}
 
-	// Vérifier que 3 messages ont été broadcastés: game_started, score_update (reset), boss_state_update (reset)
+	// Vérifier que 4 messages ont été broadcastés: game_started, score_update, boss_state_update, player_state_update
 	messages := make([][]byte, 0)
 	timeout := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(timeout) && len(messages) < 3 {
+	for time.Now().Before(timeout) && len(messages) < 4 {
 		select {
 		case broadcast := <-client.send:
 			messages = append(messages, broadcast)
@@ -213,12 +214,12 @@ func TestGameServiceHandleStartGame(t *testing.T) {
 		}
 	}
 
-	if len(messages) < 3 {
-		t.Fatalf("expected at least 3 broadcast messages, got %d", len(messages))
+	if len(messages) < 4 {
+		t.Fatalf("expected at least 4 broadcast messages, got %d", len(messages))
 	}
 
 	// Vérifier les types
-	expectedTypes := []string{"game_started", "score_update", "boss_state_update"}
+	expectedTypes := []string{"game_started", "score_update", "boss_state_update", "player_state_update"}
 	for i, expected := range expectedTypes {
 		var msgResp Message
 		if err := json.Unmarshal(messages[i], &msgResp); err != nil {
@@ -228,6 +229,51 @@ func TestGameServiceHandleStartGame(t *testing.T) {
 		if msgResp.Type != expected {
 			t.Fatalf("message %d: expected type %s, got %s", i, expected, msgResp.Type)
 		}
+	}
+}
+
+func TestGameServiceHandlePlayerDamageTest(t *testing.T) {
+	hub := newHub()
+	hub.player = newPlayerTracker(defaultPlayerConfig)
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	msg := Message{Type: "boss_attack_test"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"boss_attack_test"}`))
+
+	if isDirectResponse {
+		t.Fatal("expected boss_attack_test to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for boss_attack_test")
+	}
+
+	select {
+	case broadcast := <-client.send:
+		var msgResp Message
+		if err := json.Unmarshal(broadcast, &msgResp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if msgResp.Type != "player_state_update" {
+			t.Fatalf("expected 'player_state_update', got %s", msgResp.Type)
+		}
+
+		var payload PlayerStateUpdatePayload
+		if err := json.Unmarshal(msgResp.Payload, &payload); err != nil {
+			t.Fatalf("failed to unmarshal player payload: %v", err)
+		}
+
+		if payload.HP != 80 || payload.LastDamageTaken != 20 || payload.Balls != 3 {
+			t.Fatalf("unexpected player damage payload: %+v", payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected broadcast message not received")
 	}
 }
 

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -355,6 +355,20 @@ func TestWebSocketStartGameResetsScoreState(t *testing.T) {
 	if bossPayload.Active || bossPayload.HP != defaultBossMaxHP || bossPayload.DamageTaken != 0 {
 		t.Fatalf("expected inactive reset boss payload, got %+v", bossPayload)
 	}
+
+	playerUpdate := readMessageType(t, conn)
+	if playerUpdate.Type != "player_state_update" {
+		t.Fatalf("expected player_state_update after reset, got %s", playerUpdate.Type)
+	}
+
+	var playerPayload PlayerStateUpdatePayload
+	if err := json.Unmarshal(playerUpdate.Payload, &playerPayload); err != nil {
+		t.Fatalf("failed to unmarshal player payload: %v", err)
+	}
+
+	if playerPayload.HP != defaultPlayerMaxHP || playerPayload.Balls != defaultPlayerMaxBalls || playerPayload.GameOver {
+		t.Fatalf("expected reset player payload, got %+v", playerPayload)
+	}
 }
 
 func TestWebSocketBroadcastsBossStateUpdateAfterImpactWhileBossIsActive(t *testing.T) {
@@ -375,6 +389,7 @@ func TestWebSocketBroadcastsBossStateUpdateAfterImpactWhileBossIsActive(t *testi
 	_ = readMessageType(t, conn) // game_started
 	_ = readMessageType(t, conn) // score_update reset
 	_ = readMessageType(t, conn) // boss_state_update reset
+	_ = readMessageType(t, conn) // player_state_update reset
 
 	if err := conn.WriteJSON(Message{Type: "boss_fight_started"}); err != nil {
 		t.Fatalf("failed to send boss_fight_started: %v", err)

--- a/backend/messages.go
+++ b/backend/messages.go
@@ -61,6 +61,14 @@ func NewBossStateUpdateMessage(bossUpdate any) []byte {
 	})
 }
 
+// NewPlayerStateUpdateMessage crée le message de mise à jour de l'état du joueur
+func NewPlayerStateUpdateMessage(playerUpdate any) []byte {
+	return mustMarshalMessage(Message{
+		Type:    "player_state_update",
+		Payload: mustMarshalJSON(playerUpdate),
+	})
+}
+
 // NewImpactMessage crée le message d'impact
 func NewImpactMessage(payload json.RawMessage) []byte {
 	return mustMarshalMessage(Message{

--- a/backend/player.go
+++ b/backend/player.go
@@ -1,0 +1,122 @@
+package main
+
+import "sync"
+
+const (
+	defaultPlayerMaxHP      = 100
+	defaultPlayerMaxBalls   = 3
+	defaultBossAttackDamage = 20
+	defaultPlayerDamageTest = 20
+)
+
+type PlayerStateUpdatePayload struct {
+	HP              int    `json:"hp"`
+	MaxHP           int    `json:"maxHp"`
+	Balls           int    `json:"balls"`
+	MaxBalls        int    `json:"maxBalls"`
+	LastDamageTaken int    `json:"lastDamageTaken"`
+	LastBallLost    bool   `json:"lastBallLost"`
+	GameOver        bool   `json:"gameOver"`
+	Mode            string `json:"mode"`
+}
+
+type PlayerConfig struct {
+	MaxHP    int
+	MaxBalls int
+}
+
+type PlayerTracker struct {
+	mutex  sync.Mutex
+	config PlayerConfig
+	hp     int
+	balls  int
+}
+
+var defaultPlayerConfig = PlayerConfig{
+	MaxHP:    defaultPlayerMaxHP,
+	MaxBalls: defaultPlayerMaxBalls,
+}
+
+func newPlayerTracker(config PlayerConfig) *PlayerTracker {
+	if config.MaxHP <= 0 {
+		config.MaxHP = defaultPlayerMaxHP
+	}
+	if config.MaxBalls <= 0 {
+		config.MaxBalls = defaultPlayerMaxBalls
+	}
+
+	return &PlayerTracker{
+		config: config,
+		hp:     config.MaxHP,
+		balls:  config.MaxBalls,
+	}
+}
+
+func (p *PlayerTracker) ResetForGameStart() PlayerStateUpdatePayload {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.hp = p.config.MaxHP
+	p.balls = p.config.MaxBalls
+
+	return p.currentStateLocked(0, false, "game_started")
+}
+
+func (p *PlayerTracker) ApplyDamage(damage int) PlayerStateUpdatePayload {
+	if damage <= 0 {
+		damage = defaultPlayerDamageTest
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if p.balls <= 0 {
+		p.hp = 0
+		return p.currentStateLocked(0, false, "game_over")
+	}
+
+	p.hp -= damage
+	if p.hp > 0 {
+		return p.currentStateLocked(damage, false, "player_damage")
+	}
+
+	p.loseBallLocked()
+	return p.currentStateLocked(damage, true, "ball_lost")
+}
+
+func (p *PlayerTracker) LoseBall() PlayerStateUpdatePayload {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if p.balls <= 0 {
+		p.hp = 0
+		return p.currentStateLocked(0, false, "game_over")
+	}
+
+	p.loseBallLocked()
+	return p.currentStateLocked(0, true, "ball_lost")
+}
+
+func (p *PlayerTracker) loseBallLocked() {
+	p.balls--
+	if p.balls <= 0 {
+		p.balls = 0
+		p.hp = 0
+		return
+	}
+
+	p.hp = p.config.MaxHP
+}
+
+func (p *PlayerTracker) currentStateLocked(lastDamageTaken int, lastBallLost bool, mode string) PlayerStateUpdatePayload {
+	return PlayerStateUpdatePayload{
+		HP:              p.hp,
+		MaxHP:           p.config.MaxHP,
+		Balls:           p.balls,
+		MaxBalls:        p.config.MaxBalls,
+		LastDamageTaken: lastDamageTaken,
+		LastBallLost:    lastBallLost,
+		GameOver:        p.balls <= 0,
+		Mode:            mode,
+	}
+}

--- a/backend/player_test.go
+++ b/backend/player_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestPlayerResetForGameStart(t *testing.T) {
+	player := newPlayerTracker(defaultPlayerConfig)
+
+	state := player.ResetForGameStart()
+
+	if state.HP != defaultPlayerMaxHP || state.Balls != defaultPlayerMaxBalls || state.GameOver {
+		t.Fatalf("expected reset player state, got %+v", state)
+	}
+}
+
+func TestPlayerApplyDamageWithoutLosingBall(t *testing.T) {
+	player := newPlayerTracker(defaultPlayerConfig)
+
+	state := player.ApplyDamage(20)
+
+	if state.HP != 80 || state.Balls != 3 || state.LastBallLost || state.GameOver {
+		t.Fatalf("expected player damage without ball loss, got %+v", state)
+	}
+}
+
+func TestPlayerApplyDamageCanLoseBall(t *testing.T) {
+	player := newPlayerTracker(defaultPlayerConfig)
+
+	state := player.ApplyDamage(100)
+
+	if state.HP != defaultPlayerMaxHP || state.Balls != 2 || !state.LastBallLost || state.GameOver {
+		t.Fatalf("expected one ball lost and hp reset, got %+v", state)
+	}
+}
+
+func TestPlayerCanReachGameOver(t *testing.T) {
+	player := newPlayerTracker(defaultPlayerConfig)
+
+	player.LoseBall()
+	player.LoseBall()
+	state := player.LoseBall()
+
+	if state.HP != 0 || state.Balls != 0 || !state.GameOver {
+		t.Fatalf("expected game over after last ball, got %+v", state)
+	}
+}

--- a/backend/ws_hub.go
+++ b/backend/ws_hub.go
@@ -16,6 +16,7 @@ type Hub struct {
 	mqtt       *MQTTBridge
 	scorer     *ScoreTracker
 	boss       *BossTracker
+	player     *PlayerTracker
 	mutex      sync.RWMutex
 }
 
@@ -35,6 +36,7 @@ func newHub() *Hub {
 		unregister: make(chan *Client),
 		scorer:     newScoreTracker(defaultScoreConfig),
 		boss:       newBossTracker(defaultBossConfig),
+		player:     newPlayerTracker(defaultPlayerConfig),
 	}
 }
 

--- a/doc/Systeme_boss_fight_player_state.md
+++ b/doc/Systeme_boss_fight_player_state.md
@@ -1,0 +1,196 @@
+# Systeme de boss fight et player state
+
+Ce document definit la premiere version du systeme de boss fight, de l'etat joueur et du systeme de vies / balles pour l'issue `#118`.
+
+L'objectif est de poser une base simple, testable et equilibrable avant d'ajouter des attaques de boss plus complexes ou une integration complete avec les quetes.
+
+## Objectifs de gameplay
+
+Le systeme doit permettre de :
+
+- suivre les PV du boss ;
+- suivre les PV du joueur ;
+- gerer les balles / vies restantes ;
+- convertir le score gagne en degats infliges au boss ;
+- appliquer des degats du boss au joueur ;
+- detecter la perte d'une balle ;
+- detecter le game over ;
+- preparer l'integration future avec les quetes aleatoires.
+
+## Valeurs de base recommandees
+
+### Boss
+
+- PV maximum du boss : `1000 HP`
+- Le boss commence inactif au debut d'une partie.
+- Le boss devient actif quand le boss fight est declenche.
+- Pour les tests actuels, le boss peut etre active manuellement.
+- Plus tard, le boss devra etre active automatiquement quand les `3 quetes actives` seront terminees.
+
+### Joueur
+
+- PV maximum du joueur : `100 HP`
+- Nombre de balles / vies initiales : `3`
+- Quand les PV du joueur atteignent `0`, le joueur perd `1 balle`.
+- Apres une perte de balle, les PV du joueur reviennent a `100 HP` si au moins une balle reste disponible.
+- Si le joueur n'a plus de balle disponible, la partie passe en `game over`.
+
+## Conversion score vers degats boss
+
+Le score reste la source principale des degats infliges au boss pendant le boss fight.
+
+Regle actuelle :
+
+```text
+Degats boss = Delta de score x coefficient de degats
+```
+
+Valeur recommandee pour le MVP :
+
+```text
+coefficient de degats = 0.10
+```
+
+Exemples :
+
+| Action | Delta de score | Degats boss |
+|--------|----------------|-------------|
+| Bumper simple | `+50 pts` | `5 degats` |
+| Cible simple | `+100 pts` | `10 degats` |
+| Rampe simple | `+500 pts` | `50 degats` |
+| Rampe parfaite | `+750 pts` | `75 degats` |
+| Super combo rampe | `+2000 pts` bonus | `200 degats` bonus |
+
+Cette regle permet de recompenser directement les actions fortes du joueur : plus le joueur marque de points pendant le boss fight, plus il inflige de degats.
+
+## Degats du boss vers le joueur
+
+Pour la premiere implementation, les degats du boss doivent rester simples et faciles a tester.
+
+Valeurs recommandees :
+
+| Type d'attaque | Degats joueur | Usage |
+|----------------|---------------|-------|
+| Attaque faible | `10 HP` | attaque rapide ou erreur legere |
+| Attaque moyenne | `20 HP` | valeur de test principale |
+| Attaque forte | `35 HP` | attaque plus dangereuse |
+
+Pour le MVP technique, on peut commencer avec une seule valeur :
+
+```text
+boss_attack = 20 degats joueur
+```
+
+Avec `100 HP`, le joueur peut donc encaisser `5 attaques moyennes` avant de perdre une balle.
+
+Avec `3 balles`, le joueur peut encaisser environ `15 attaques moyennes` au total avant le game over.
+
+## Boucle de boss fight cible
+
+La boucle visee est :
+
+1. Le joueur commence une partie.
+2. Le score, le boss et le player state sont reinitialises.
+3. Le joueur termine les quetes de la phase.
+4. Le boss fight est declenche.
+5. Les impacts du joueur generent du score.
+6. Le score genere des degats sur le boss.
+7. Le boss peut infliger des degats au joueur.
+8. Si les PV du joueur atteignent `0`, une balle est consommee.
+9. Si aucune balle ne reste, la partie passe en `game over`.
+10. Si les PV du boss atteignent `0`, le boss est vaincu.
+
+## Etats attendus
+
+### Etat du boss
+
+Message deja existant :
+
+```json
+{
+  "type": "boss_state_update",
+  "payload": {
+    "active": true,
+    "hp": 925,
+    "maxHp": 1000,
+    "damageTaken": 75,
+    "coefficient": 0.1,
+    "defeated": false,
+    "mode": "score_damage"
+  }
+}
+```
+
+### Etat du joueur
+
+Message a ajouter :
+
+```json
+{
+  "type": "player_state_update",
+  "payload": {
+    "hp": 100,
+    "maxHp": 100,
+    "balls": 3,
+    "maxBalls": 3,
+    "lastDamageTaken": 0,
+    "lastBallLost": false,
+    "gameOver": false,
+    "mode": "game_started"
+  }
+}
+```
+
+## Evenements techniques temporaires
+
+Comme les attaques reelles du boss ne sont pas encore implementees, des evenements temporaires peuvent etre ajoutes pour tester le systeme.
+
+Evenements possibles :
+
+- `player_damage_test` : applique des degats fixes au joueur ;
+- `boss_attack_test` : simule une attaque moyenne du boss ;
+- `ball_lost` : force la perte d'une balle ;
+- `start_game` : reinitialise le score, le boss et le player state.
+
+Ces evenements servent uniquement a valider la logique tant que la partie 3D et les attaques du boss ne sont pas finalisees.
+
+## Touches de test frontend
+
+Pendant le developpement, le frontend expose des touches simples pour tester la logique sans attendre les vraies attaques du boss :
+
+| Touche | Action |
+|--------|--------|
+| `B` | active / desactive le boss fight |
+| `H` | simule une attaque du boss et retire `20 HP` au joueur |
+| `L` | simule une perte de balle |
+
+Ces touches sont temporaires et servent uniquement au debug gameplay.
+
+## Equilibrage initial
+
+Le premier equilibrage recommande est :
+
+```text
+Boss HP: 1000
+Player HP: 100
+Balles / vies: 3
+Degats boss vers joueur: 20
+Degats joueur vers boss: score_delta x 0.10
+```
+
+Ce reglage donne une base lisible :
+
+- le joueur doit produire du score pour vaincre le boss ;
+- les grosses actions de score deviennent importantes pendant le boss fight ;
+- le joueur peut faire plusieurs erreurs avant le game over ;
+- la difficulte pourra etre ajustee apres les premiers tests jouables.
+
+## Points a ajuster plus tard
+
+Apres integration et tests, il faudra probablement ajuster :
+
+- les PV du boss selon la duree moyenne d'une phase ;
+- le coefficient de degats `0.10` si le boss tombe trop vite ou trop lentement ;
+- les degats du boss selon la frequence des attaques ;
+- le nombre de balles si le jeu devient trop facile ou trop punitif ;
+- les recompenses apres chaque boss de phase.

--- a/frontend/flipper/core/Controls.js
+++ b/frontend/flipper/core/Controls.js
@@ -12,6 +12,8 @@ export class Controls{
         this.right = right;
         this.launch = launch;
         this.bossDebug = bossDebug;
+        this.playerDamageDebug = 'h';
+        this.ballLostDebug = 'l';
 
         this.input = { left: false, right: false, launch: false, launchPower: 0 };
 
@@ -22,6 +24,8 @@ export class Controls{
         this.impulseUsed = false;
         this.startGameCallback = null;
         this.bossFightStartCallback = null;
+        this.playerDamageCallback = null;
+        this.ballLostCallback = null;
 
         this.initControls();
     }
@@ -64,6 +68,20 @@ export class Controls{
                 if (e.repeat) return;
                 if (typeof this.bossFightStartCallback === 'function') {
                     this.bossFightStartCallback();
+                }
+                return;
+            }
+            if (key === this.playerDamageDebug) {
+                if (e.repeat) return;
+                if (typeof this.playerDamageCallback === 'function') {
+                    this.playerDamageCallback();
+                }
+                return;
+            }
+            if (key === this.ballLostDebug) {
+                if (e.repeat) return;
+                if (typeof this.ballLostCallback === 'function') {
+                    this.ballLostCallback();
                 }
             }
         });
@@ -119,6 +137,14 @@ export class Controls{
 
     setBossFightStartCallback(callback) {
         this.bossFightStartCallback = callback;
+    }
+
+    setPlayerDamageCallback(callback) {
+        this.playerDamageCallback = callback;
+    }
+
+    setBallLostCallback(callback) {
+        this.ballLostCallback = callback;
     }
 
     getLaunchChargeCount() {

--- a/frontend/flipper/core/Flipper.js
+++ b/frontend/flipper/core/Flipper.js
@@ -44,6 +44,12 @@ async function initFlipper() {
     controls.setBossFightStartCallback(() => {
         physics.sendMessage('boss_fight_toggled');
     });
+    controls.setPlayerDamageCallback(() => {
+        physics.sendMessage('boss_attack_test');
+    });
+    controls.setBallLostCallback(() => {
+        physics.sendMessage('ball_lost');
+    });
 
     const mesh = [];
 

--- a/frontend/flipper/ui/ScoreDisplay.js
+++ b/frontend/flipper/ui/ScoreDisplay.js
@@ -8,7 +8,14 @@ const DEFAULT_STATE = {
     bossHp: 0,
     bossMaxHp: 0,
     bossDamageTaken: 0,
-    bossDefeated: false
+    bossDefeated: false,
+    playerHp: 0,
+    playerMaxHp: 0,
+    playerBalls: 0,
+    playerMaxBalls: 0,
+    playerLastDamageTaken: 0,
+    playerLastBallLost: false,
+    gameOver: false
 };
 
 export class ScoreDisplay {
@@ -23,6 +30,10 @@ export class ScoreDisplay {
         this.detailValue = null;
         this.bossValue = null;
         this.bossDetailValue = null;
+        this.playerValue = null;
+        this.playerBallsValue = null;
+        this.playerDetailValue = null;
+        this.controlsContainer = null;
         this.boundHandler = (event) => this.handleBackendEvent(event?.detail);
     }
 
@@ -107,6 +118,31 @@ export class ScoreDisplay {
             opacity: '0.92'
         });
 
+        this.playerValue = this.documentRef.createElement('div');
+        Object.assign(this.playerValue.style, {
+            fontSize: '12px',
+            marginTop: '10px',
+            paddingTop: '10px',
+            borderTop: '1px solid rgba(126, 255, 179, 0.14)',
+            color: '#b8d7ff'
+        });
+
+        this.playerDetailValue = this.documentRef.createElement('div');
+        Object.assign(this.playerDetailValue.style, {
+            fontSize: '11px',
+            marginTop: '6px',
+            color: '#c7ffbd',
+            opacity: '0.92'
+        });
+
+        this.playerBallsValue = this.documentRef.createElement('div');
+        Object.assign(this.playerBallsValue.style, {
+            fontSize: '11px',
+            marginTop: '6px',
+            color: '#b8d7ff',
+            opacity: '0.94'
+        });
+
         this.container.appendChild(title);
         this.container.appendChild(this.scoreValue);
         this.container.appendChild(this.comboValue);
@@ -114,7 +150,11 @@ export class ScoreDisplay {
         this.container.appendChild(this.detailValue);
         this.container.appendChild(this.bossValue);
         this.container.appendChild(this.bossDetailValue);
+        this.container.appendChild(this.playerValue);
+        this.container.appendChild(this.playerBallsValue);
+        this.container.appendChild(this.playerDetailValue);
         container.appendChild(this.container);
+        this.mountControlsHelp(container);
 
         if (typeof this.eventTarget?.addEventListener === 'function') {
             this.eventTarget.addEventListener('flipper:backend-message', this.boundHandler);
@@ -122,6 +162,82 @@ export class ScoreDisplay {
 
         this.render();
         return this.container;
+    }
+
+    mountControlsHelp(container) {
+        this.controlsContainer = this.documentRef.createElement('aside');
+        this.controlsContainer.setAttribute('aria-label', 'Flipper controls help');
+        Object.assign(this.controlsContainer.style, {
+            position: 'fixed',
+            top: '24px',
+            right: '24px',
+            zIndex: '20',
+            minWidth: '240px',
+            padding: '16px 18px',
+            borderRadius: '14px',
+            border: '1px solid rgba(126, 215, 255, 0.22)',
+            background: 'linear-gradient(180deg, rgba(9, 12, 20, 0.92) 0%, rgba(5, 7, 14, 0.88) 100%)',
+            boxShadow: '0 16px 40px rgba(0, 0, 0, 0.35)',
+            color: '#dff5ff',
+            fontFamily: 'monospace',
+            pointerEvents: 'none'
+        });
+
+        const title = this.documentRef.createElement('div');
+        title.textContent = 'CONTRÔLES';
+        Object.assign(title.style, {
+            fontSize: '13px',
+            letterSpacing: '0.22em',
+            opacity: '0.78',
+            marginBottom: '10px'
+        });
+
+        this.controlsContainer.appendChild(title);
+
+        const controls = [
+            ['Q', 'Flipper gauche'],
+            ['D', 'Flipper droit'],
+            ['Espace', 'Lancer la bille / démarrer'],
+            ['B', 'Activer / désactiver le boss'],
+            ['H', 'Test attaque boss: -20 HP'],
+            ['L', 'Test perte de balle']
+        ];
+
+        for (const [key, label] of controls) {
+            this.controlsContainer.appendChild(this.createControlLine(key, label));
+        }
+
+        container.appendChild(this.controlsContainer);
+    }
+
+    createControlLine(key, label) {
+        const line = this.documentRef.createElement('div');
+        Object.assign(line.style, {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            marginBottom: '8px',
+            fontSize: '12px',
+            color: '#c8d6ea'
+        });
+
+        const keyElement = this.documentRef.createElement('span');
+        keyElement.textContent = key;
+        Object.assign(keyElement.style, {
+            minWidth: '52px',
+            padding: '3px 6px',
+            borderRadius: '6px',
+            border: '1px solid rgba(126, 215, 255, 0.24)',
+            color: '#7ed7ff',
+            textAlign: 'center'
+        });
+
+        const labelElement = this.documentRef.createElement('span');
+        labelElement.textContent = label;
+
+        line.appendChild(keyElement);
+        line.appendChild(labelElement);
+        return line;
     }
 
     handleBackendEvent(message) {
@@ -147,6 +263,17 @@ export class ScoreDisplay {
                 bossDamageTaken: Number(message.payload.damageTaken ?? 0),
                 bossDefeated: Boolean(message.payload.defeated)
             };
+        } else if (message.type === 'player_state_update') {
+            this.state = {
+                ...this.state,
+                playerHp: Number(message.payload.hp ?? 0),
+                playerMaxHp: Number(message.payload.maxHp ?? 0),
+                playerBalls: Number(message.payload.balls ?? 0),
+                playerMaxBalls: Number(message.payload.maxBalls ?? 0),
+                playerLastDamageTaken: Number(message.payload.lastDamageTaken ?? 0),
+                playerLastBallLost: Boolean(message.payload.lastBallLost),
+                gameOver: Boolean(message.payload.gameOver)
+            };
         } else {
             return false;
         }
@@ -168,6 +295,9 @@ export class ScoreDisplay {
             : 'En attente des impacts';
         this.bossValue.textContent = this.formatBossLabel();
         this.bossDetailValue.textContent = this.formatBossDetail();
+        this.playerValue.textContent = this.formatPlayerLabel();
+        this.playerBallsValue.textContent = this.formatPlayerBalls();
+        this.playerDetailValue.textContent = this.formatPlayerDetail();
     }
 
     formatScore(value) {
@@ -194,5 +324,41 @@ export class ScoreDisplay {
         return this.state.bossDamageTaken > 0
             ? `Derniers dégâts boss: -${this.state.bossDamageTaken}`
             : 'Dégâts boss: en attente';
+    }
+
+    formatPlayerLabel() {
+        if (this.state.playerMaxHp <= 0) {
+            return 'Joueur: en attente';
+        }
+
+        if (this.state.gameOver) {
+            return `Joueur: game over (${this.state.playerBalls}/${this.state.playerMaxBalls} balles)`;
+        }
+
+        return `Joueur: ${this.state.playerHp}/${this.state.playerMaxHp} HP`;
+    }
+
+    formatPlayerDetail() {
+        if (this.state.playerMaxHp <= 0) {
+            return 'État joueur: --';
+        }
+
+        if (this.state.playerLastBallLost) {
+            return 'Balle perdue';
+        }
+
+        if (this.state.playerLastDamageTaken > 0) {
+            return `Derniers dégâts joueur: -${this.state.playerLastDamageTaken}`;
+        }
+
+        return 'Dégâts joueur: en attente';
+    }
+
+    formatPlayerBalls() {
+        if (this.state.playerMaxBalls <= 0) {
+            return 'Balles: --';
+        }
+
+        return `Balles: ${this.state.playerBalls}/${this.state.playerMaxBalls}`;
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "lint": "node ./scripts/lint.mjs",
     "test": "npm run test:frontend",
     "test:backend": "cd backend && go test ./...",
-    "test:frontend": "node --test tests/frontend/config.test.js tests/frontend/game-physics.test.js tests/frontend/objects.test.js",
+    "test:frontend": "node --test tests/frontend/config.test.js tests/frontend/game-physics.test.js tests/frontend/objects.test.js tests/frontend/controls.test.js tests/frontend/score-display.test.js",
     "build": "node -e \"console.log('Frontend build placeholder: no bundler configured yet')\""
   },
   "dependencies": {

--- a/tests/frontend/controls.test.js
+++ b/tests/frontend/controls.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { Controls } from '../../frontend/core/Controls.js';
+import { Controls } from '../../frontend/flipper/core/Controls.js';
 
 function createWindowStub() {
   const listeners = new Map();
@@ -63,6 +63,31 @@ test('Controls triggers boss_fight_started callback on debug key press', () => {
   windowStub.listeners.get('keydown')({ key: 'b', preventDefault() {}, repeat: false });
 
   assert.equal(bossFightCalls, 1);
+
+  globalThis.window = previousWindow;
+});
+
+test('Controls triggers player damage and ball lost callbacks on debug keys', () => {
+  const previousWindow = globalThis.window;
+  const windowStub = createWindowStub();
+  globalThis.window = windowStub;
+
+  const controls = new Controls('q', 'd', 'space', 'b');
+  let damageCalls = 0;
+  let ballLostCalls = 0;
+
+  controls.setPlayerDamageCallback(() => {
+    damageCalls += 1;
+  });
+  controls.setBallLostCallback(() => {
+    ballLostCalls += 1;
+  });
+
+  windowStub.listeners.get('keydown')({ key: 'h', preventDefault() {}, repeat: false });
+  windowStub.listeners.get('keydown')({ key: 'l', preventDefault() {}, repeat: false });
+
+  assert.equal(damageCalls, 1);
+  assert.equal(ballLostCalls, 1);
 
   globalThis.window = previousWindow;
 });

--- a/tests/frontend/score-display.test.js
+++ b/tests/frontend/score-display.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { ScoreDisplay } from '../../frontend/ui/ScoreDisplay.js';
+import { ScoreDisplay } from '../../frontend/flipper/ui/ScoreDisplay.js';
 
 function createFakeElement(tagName) {
   return {
@@ -39,13 +39,41 @@ test('ScoreDisplay mounts with default values', () => {
   const mounted = display.mount();
 
   assert.equal(mounted, display.container);
-  assert.equal(documentRef.body.children.length, 1);
+  assert.equal(documentRef.body.children.length, 2);
   assert.equal(display.scoreValue.textContent, '0');
   assert.equal(display.comboValue.textContent, 'Combo x1');
   assert.equal(display.deltaValue.textContent, '+0');
   assert.equal(display.detailValue.textContent, 'En attente des impacts');
   assert.equal(display.bossValue.textContent, 'Boss: en attente');
   assert.equal(display.bossDetailValue.textContent, 'Dégâts boss: --');
+  assert.equal(display.playerValue.textContent, 'Joueur: en attente');
+  assert.equal(display.playerBallsValue.textContent, 'Balles: --');
+  assert.equal(display.playerDetailValue.textContent, 'État joueur: --');
+  assert.equal(display.controlsContainer.children[0].textContent, 'CONTRÔLES');
+});
+
+test('ScoreDisplay updates player state when receiving player_state_update', () => {
+  const documentRef = createFakeDocument();
+  const display = new ScoreDisplay({ documentRef, eventTarget: null });
+  display.mount();
+
+  const handled = display.handleBackendEvent({
+    type: 'player_state_update',
+    payload: {
+      hp: 80,
+      maxHp: 100,
+      balls: 3,
+      maxBalls: 3,
+      lastDamageTaken: 20,
+      lastBallLost: false,
+      gameOver: false
+    }
+  });
+
+  assert.equal(handled, true);
+  assert.equal(display.playerValue.textContent, 'Joueur: 80/100 HP');
+  assert.equal(display.playerBallsValue.textContent, 'Balles: 3/3');
+  assert.equal(display.playerDetailValue.textContent, 'Derniers dégâts joueur: -20');
 });
 
 test('ScoreDisplay updates its fields when receiving score_update', () => {


### PR DESCRIPTION
## Résumé

Cette PR ajoute la première base du boss fight côté player state.

## Changements

- Ajout d'un état joueur avec HP, balles restantes et game over.
- Ajout du message WebSocket `player_state_update`.
- Réinitialisation du player state au `start_game`.
- Ajout d'événements temporaires de test : `boss_attack_test`, `player_damage_test`, `ball_lost`.
- Mise à jour du HUD pour afficher les HP joueur, les balles restantes et les contrôles de test.
- Ajout de la documentation du système de boss fight / player state.
- Ajout et mise à jour des tests backend et frontend.

## Tests

- `npm test`
- `npm run test:backend`
- `npm run lint`