### PR TITLE
Gameplay : Implémentation du système de quêtes aléatoires

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,7 @@ Variables utiles:
 | `score_update` | Serveur → Client | Nouveau score calculé avec delta et combo courant |
 | `boss_state_update` | Serveur → Client | État courant du boss (HP, activation, dégâts) |
 | `player_state_update` | Serveur → Client | État courant du joueur (HP, balles, game over) |
+| `quest_update` | Serveur → Client | État courant des quêtes actives |
 | `flipper_action` | Client → Serveur | Action sur les flippers (left/right) |
 | `impact` | Client → Serveur | Contact détecté côté frontend (bumper, palle, mur, rampe) |
 | `game_state` | Bidirectionnel | État actuel du jeu |
@@ -142,6 +143,7 @@ Topics utilisés:
 | `score.go` | Calcul de score, combo, multiplicateurs |
 | `boss.go` | Gestion de l'état du boss (HP, phases, dégâts) |
 | `player.go` | Gestion de l'état du joueur (HP, balles, game over) |
+| `quest.go` | Gestion des quêtes actives, progression et déclenchement boss |
 | `mqtt_bridge.go` | Pont vers Mosquitto, publication solénoïdes, souscription capteurs |
 | `mqtt_publisher.go` | Utilitaires de publication MQTT |
 
@@ -168,6 +170,7 @@ backend/
 │
 ├── boss.go                  # Gestion boss
 ├── player.go                # Gestion joueur
+├── quest.go                 # Gestion quêtes
 │
 ├── mqtt_bridge.go           # Pont MQTT + config
 ├── mqtt_bridge_test.go      # Tests du pont MQTT
@@ -203,6 +206,7 @@ Tous les tests passent via `go test ./...`:
 9. Broadcast `boss_state_update` vers tous les clients
 
 Au démarrage d'une partie, le backend réinitialise aussi l'état joueur et diffuse `player_state_update`.
+Il tire également `3 quêtes actives` et diffuse `quest_update`.
 
 ## Commandes utiles
 

--- a/backend/boss.go
+++ b/backend/boss.go
@@ -116,6 +116,13 @@ func (b *BossTracker) ApplyScoreDamage(scoreDelta int) (BossStateUpdatePayload, 
 	return b.currentStateLocked(damage, "score_damage"), true
 }
 
+func (b *BossTracker) IsActive() bool {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.active
+}
+
 func (b *BossTracker) currentStateLocked(damageTaken int, mode string) BossStateUpdatePayload {
 	return BossStateUpdatePayload{
 		Active:      b.active,

--- a/backend/game_service.go
+++ b/backend/game_service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"time"
 )
 
 // GameService encapsule la logique métier des messages WebSocket
@@ -88,9 +89,24 @@ func (gs *GameService) handleImpact(payload json.RawMessage) {
 	if scoreUpdate, ok := gs.hub.scorer.ApplyImpact(impact); ok {
 		gs.hub.broadcast <- NewScoreUpdateMessage(scoreUpdate)
 
+		shouldStartBoss := false
+		if !gs.hub.boss.IsActive() {
+			questUpdate, ok := gs.hub.quests.UpdateAfterImpact(scoreUpdate, impact)
+			if ok {
+				gs.hub.broadcast <- NewQuestUpdateMessage(questUpdate)
+				if questUpdate.BossFightTriggered {
+					shouldStartBoss = true
+				}
+			}
+		}
+
 		// Appliquer les dégâts au boss
 		if bossUpdate, ok := gs.hub.boss.ApplyScoreDamage(scoreUpdate.Delta); ok {
 			gs.hub.broadcast <- NewBossStateUpdateMessage(bossUpdate)
+		}
+
+		if shouldStartBoss {
+			gs.hub.broadcast <- NewBossStateUpdateMessage(gs.hub.boss.StartBossFight())
 		}
 	}
 }
@@ -120,6 +136,9 @@ func (gs *GameService) handleStartGame() {
 
 	// Broadcaster reset joueur
 	gs.hub.broadcast <- NewPlayerStateUpdateMessage(gs.hub.player.ResetForGameStart())
+
+	// Broadcaster les quêtes tirées pour cette partie
+	gs.hub.broadcast <- NewQuestUpdateMessage(gs.hub.quests.ResetForGameStart(time.Now().UnixMilli()))
 }
 
 // handleBossFightStarted traite l'activation du combat de boss

--- a/backend/game_service_test.go
+++ b/backend/game_service_test.go
@@ -203,10 +203,10 @@ func TestGameServiceHandleStartGame(t *testing.T) {
 		t.Fatal("expected nil response for start_game")
 	}
 
-	// Vérifier que 4 messages ont été broadcastés: game_started, score_update, boss_state_update, player_state_update
+	// Vérifier que 5 messages ont été broadcastés: game_started, score_update, boss_state_update, player_state_update, quest_update
 	messages := make([][]byte, 0)
 	timeout := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(timeout) && len(messages) < 4 {
+	for time.Now().Before(timeout) && len(messages) < 5 {
 		select {
 		case broadcast := <-client.send:
 			messages = append(messages, broadcast)
@@ -214,12 +214,12 @@ func TestGameServiceHandleStartGame(t *testing.T) {
 		}
 	}
 
-	if len(messages) < 4 {
-		t.Fatalf("expected at least 4 broadcast messages, got %d", len(messages))
+	if len(messages) < 5 {
+		t.Fatalf("expected at least 5 broadcast messages, got %d", len(messages))
 	}
 
 	// Vérifier les types
-	expectedTypes := []string{"game_started", "score_update", "boss_state_update", "player_state_update"}
+	expectedTypes := []string{"game_started", "score_update", "boss_state_update", "player_state_update", "quest_update"}
 	for i, expected := range expectedTypes {
 		var msgResp Message
 		if err := json.Unmarshal(messages[i], &msgResp); err != nil {

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -369,6 +369,20 @@ func TestWebSocketStartGameResetsScoreState(t *testing.T) {
 	if playerPayload.HP != defaultPlayerMaxHP || playerPayload.Balls != defaultPlayerMaxBalls || playerPayload.GameOver {
 		t.Fatalf("expected reset player payload, got %+v", playerPayload)
 	}
+
+	questUpdate := readMessageType(t, conn)
+	if questUpdate.Type != "quest_update" {
+		t.Fatalf("expected quest_update after reset, got %s", questUpdate.Type)
+	}
+
+	var questPayload QuestUpdatePayload
+	if err := json.Unmarshal(questUpdate.Payload, &questPayload); err != nil {
+		t.Fatalf("failed to unmarshal quest payload: %v", err)
+	}
+
+	if len(questPayload.ActiveQuests) != 3 || questPayload.CompletedCount != 0 {
+		t.Fatalf("expected 3 fresh active quests, got %+v", questPayload)
+	}
 }
 
 func TestWebSocketBroadcastsBossStateUpdateAfterImpactWhileBossIsActive(t *testing.T) {
@@ -390,6 +404,7 @@ func TestWebSocketBroadcastsBossStateUpdateAfterImpactWhileBossIsActive(t *testi
 	_ = readMessageType(t, conn) // score_update reset
 	_ = readMessageType(t, conn) // boss_state_update reset
 	_ = readMessageType(t, conn) // player_state_update reset
+	_ = readMessageType(t, conn) // quest_update reset
 
 	if err := conn.WriteJSON(Message{Type: "boss_fight_started"}); err != nil {
 		t.Fatalf("failed to send boss_fight_started: %v", err)

--- a/backend/messages.go
+++ b/backend/messages.go
@@ -69,6 +69,14 @@ func NewPlayerStateUpdateMessage(playerUpdate any) []byte {
 	})
 }
 
+// NewQuestUpdateMessage crée le message de mise à jour des quêtes actives
+func NewQuestUpdateMessage(questUpdate any) []byte {
+	return mustMarshalMessage(Message{
+		Type:    "quest_update",
+		Payload: mustMarshalJSON(questUpdate),
+	})
+}
+
 // NewImpactMessage crée le message d'impact
 func NewImpactMessage(payload json.RawMessage) []byte {
 	return mustMarshalMessage(Message{

--- a/backend/quest.go
+++ b/backend/quest.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Quest struct {
+	ID        string `json:"id"`
+	Category  string `json:"category"`
+	Label     string `json:"label"`
+	Target    int    `json:"target"`
+	Progress  int    `json:"progress"`
+	Completed bool   `json:"completed"`
+}
+
+type QuestUpdatePayload struct {
+	ActiveQuests       []Quest `json:"activeQuests"`
+	CompletedCount     int     `json:"completedCount"`
+	RequiredCount      int     `json:"requiredCount"`
+	AllCompleted       bool    `json:"allCompleted"`
+	BossFightTriggered bool    `json:"bossFightTriggered"`
+	Mode               string  `json:"mode"`
+}
+
+type QuestTracker struct {
+	mutex              sync.Mutex
+	pool               []Quest
+	activeQuests       []Quest
+	loopLeftDone       bool
+	loopRightDone      bool
+	phaseStartedAt     int64
+	bossFightTriggered bool
+	random             *rand.Rand
+}
+
+func newQuestTracker() *QuestTracker {
+	return &QuestTracker{
+		pool:   defaultQuestPool(),
+		random: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func defaultQuestPool() []Quest {
+	return []Quest{
+		{ID: "score_2000", Category: "score", Label: "Atteindre 2 000 points", Target: 2000},
+		{ID: "score_3500", Category: "score", Label: "Atteindre 3 500 points", Target: 3500},
+		{ID: "combo_x3", Category: "score", Label: "Atteindre un combo x3", Target: 3},
+		{ID: "target_center_2", Category: "precision", Label: "Toucher 2 fois la zone centrale d'une cible basse", Target: 2},
+		{ID: "ramp_perfect_1", Category: "precision", Label: "Réussir 1 rampe parfaite", Target: 1},
+		{ID: "ramp_simple_2", Category: "precision", Label: "Réussir 2 passages de rampe", Target: 2},
+		{ID: "loop_left_right", Category: "exploration", Label: "Passer une fois par chaque loop latéral", Target: 2},
+		{ID: "bumpers_5", Category: "exploration", Label: "Toucher 5 bumpers au total", Target: 5},
+		{ID: "survive_20s", Category: "exploration", Label: "Survivre 20 secondes avec la même bille", Target: 20},
+	}
+}
+
+func (q *QuestTracker) ResetForGameStart(startedAt int64) QuestUpdatePayload {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	if startedAt <= 0 {
+		startedAt = time.Now().UnixMilli()
+	}
+
+	q.phaseStartedAt = startedAt
+	q.loopLeftDone = false
+	q.loopRightDone = false
+	q.bossFightTriggered = false
+	q.activeQuests = q.drawActiveQuestsLocked()
+
+	return q.currentStateLocked("quests_started")
+}
+
+func (q *QuestTracker) UpdateAfterImpact(score ScoreUpdatePayload, impact ImpactPayload) (QuestUpdatePayload, bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	if len(q.activeQuests) == 0 {
+		return QuestUpdatePayload{}, false
+	}
+
+	changed := false
+	for index := range q.activeQuests {
+		before := q.activeQuests[index]
+		q.updateQuestLocked(&q.activeQuests[index], score, impact)
+
+		if before.Progress != q.activeQuests[index].Progress || before.Completed != q.activeQuests[index].Completed {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return QuestUpdatePayload{}, false
+	}
+
+	if q.allCompletedLocked() && !q.bossFightTriggered {
+		q.bossFightTriggered = true
+	}
+
+	return q.currentStateLocked("quest_progress"), true
+}
+
+func (q *QuestTracker) drawActiveQuestsLocked() []Quest {
+	categories := []string{"score", "precision", "exploration"}
+	active := make([]Quest, 0, len(categories))
+
+	for _, category := range categories {
+		choices := make([]Quest, 0)
+		for _, quest := range q.pool {
+			if quest.Category == category {
+				quest.Progress = 0
+				quest.Completed = false
+				choices = append(choices, quest)
+			}
+		}
+
+		if len(choices) == 0 {
+			continue
+		}
+
+		active = append(active, choices[q.random.Intn(len(choices))])
+	}
+
+	return active
+}
+
+func (q *QuestTracker) updateQuestLocked(quest *Quest, score ScoreUpdatePayload, impact ImpactPayload) {
+	if quest.Completed {
+		return
+	}
+
+	switch quest.ID {
+	case "score_2000", "score_3500":
+		quest.Progress = clampQuestProgress(score.Score, quest.Target)
+
+	case "combo_x3":
+		quest.Progress = clampQuestProgress(score.ComboCount, quest.Target)
+
+	case "target_center_2":
+		if isTargetCenterImpact(impact) {
+			quest.Progress++
+		}
+
+	case "ramp_perfect_1":
+		if impact.ObjectID == "ramp-main-perfect" {
+			quest.Progress++
+		}
+
+	case "ramp_simple_2":
+		if impact.ObjectID == "ramp-main-simple" || impact.ObjectID == "ramp-main-perfect" {
+			quest.Progress++
+		}
+
+	case "loop_left_right":
+		if impact.ObjectID == "loop-left" {
+			q.loopLeftDone = true
+		}
+		if impact.ObjectID == "loop-right" {
+			q.loopRightDone = true
+		}
+
+		quest.Progress = 0
+		if q.loopLeftDone {
+			quest.Progress++
+		}
+		if q.loopRightDone {
+			quest.Progress++
+		}
+
+	case "bumpers_5":
+		if impact.ObjectType == "bumper" {
+			quest.Progress++
+		}
+
+	case "survive_20s":
+		if q.phaseStartedAt > 0 && impact.Timestamp > q.phaseStartedAt {
+			seconds := int((impact.Timestamp - q.phaseStartedAt) / 1000)
+			quest.Progress = clampQuestProgress(seconds, quest.Target)
+		}
+	}
+
+	quest.Progress = clampQuestProgress(quest.Progress, quest.Target)
+	if quest.Progress >= quest.Target {
+		quest.Completed = true
+	}
+}
+
+func (q *QuestTracker) currentStateLocked(mode string) QuestUpdatePayload {
+	completed := 0
+	for _, quest := range q.activeQuests {
+		if quest.Completed {
+			completed++
+		}
+	}
+
+	return QuestUpdatePayload{
+		ActiveQuests:       append([]Quest(nil), q.activeQuests...),
+		CompletedCount:     completed,
+		RequiredCount:      len(q.activeQuests),
+		AllCompleted:       len(q.activeQuests) > 0 && completed == len(q.activeQuests),
+		BossFightTriggered: q.bossFightTriggered,
+		Mode:               mode,
+	}
+}
+
+func (q *QuestTracker) allCompletedLocked() bool {
+	if len(q.activeQuests) == 0 {
+		return false
+	}
+
+	for _, quest := range q.activeQuests {
+		if !quest.Completed {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isTargetCenterImpact(impact ImpactPayload) bool {
+	if impact.ObjectType != "target" {
+		return false
+	}
+
+	id := strings.ToLower(impact.ObjectID)
+	return strings.Contains(id, "center") || strings.Contains(id, "centre")
+}
+
+func clampQuestProgress(value, target int) int {
+	if value < 0 {
+		return 0
+	}
+	if target > 0 && value > target {
+		return target
+	}
+	return value
+}

--- a/backend/quest_test.go
+++ b/backend/quest_test.go
@@ -1,0 +1,90 @@
+package main
+
+import "testing"
+
+func TestQuestTrackerDrawsOneQuestPerCategory(t *testing.T) {
+	tracker := newQuestTracker()
+
+	state := tracker.ResetForGameStart(1000)
+
+	if len(state.ActiveQuests) != 3 {
+		t.Fatalf("expected 3 active quests, got %+v", state)
+	}
+
+	categories := map[string]bool{}
+	for _, quest := range state.ActiveQuests {
+		categories[quest.Category] = true
+	}
+
+	for _, category := range []string{"score", "precision", "exploration"} {
+		if !categories[category] {
+			t.Fatalf("expected category %s in active quests, got %+v", category, state.ActiveQuests)
+		}
+	}
+}
+
+func TestQuestTrackerProgressesTargetCenterQuest(t *testing.T) {
+	tracker := newQuestTracker()
+	tracker.activeQuests = []Quest{
+		{ID: "target_center_2", Category: "precision", Label: "Toucher 2 fois la zone centrale d'une cible basse", Target: 2},
+	}
+
+	first, ok := tracker.UpdateAfterImpact(ScoreUpdatePayload{}, ImpactPayload{
+		ObjectID:   "target-left-centre",
+		ObjectType: "target",
+	})
+	if !ok {
+		t.Fatal("expected quest progress after first target center")
+	}
+	if first.ActiveQuests[0].Progress != 1 || first.ActiveQuests[0].Completed {
+		t.Fatalf("expected progress 1/2, got %+v", first.ActiveQuests[0])
+	}
+
+	second, ok := tracker.UpdateAfterImpact(ScoreUpdatePayload{}, ImpactPayload{
+		ObjectID:   "target-right-centre",
+		ObjectType: "target",
+	})
+	if !ok {
+		t.Fatal("expected quest progress after second target center")
+	}
+	if !second.ActiveQuests[0].Completed || !second.AllCompleted || !second.BossFightTriggered {
+		t.Fatalf("expected quest completed and boss triggered, got %+v", second)
+	}
+}
+
+func TestQuestTrackerProgressesScoreQuest(t *testing.T) {
+	tracker := newQuestTracker()
+	tracker.activeQuests = []Quest{
+		{ID: "score_2000", Category: "score", Label: "Atteindre 2 000 points", Target: 2000},
+	}
+
+	state, ok := tracker.UpdateAfterImpact(ScoreUpdatePayload{Score: 2100}, ImpactPayload{})
+	if !ok {
+		t.Fatal("expected score quest progress")
+	}
+
+	if state.ActiveQuests[0].Progress != 2000 || !state.ActiveQuests[0].Completed {
+		t.Fatalf("expected completed score quest, got %+v", state.ActiveQuests[0])
+	}
+}
+
+func TestQuestTrackerProgressesLoopQuestWithBothSides(t *testing.T) {
+	tracker := newQuestTracker()
+	tracker.activeQuests = []Quest{
+		{ID: "loop_left_right", Category: "exploration", Label: "Passer une fois par chaque loop latéral", Target: 2},
+	}
+
+	_, ok := tracker.UpdateAfterImpact(ScoreUpdatePayload{}, ImpactPayload{ObjectID: "loop-left"})
+	if !ok {
+		t.Fatal("expected loop-left to progress quest")
+	}
+
+	state, ok := tracker.UpdateAfterImpact(ScoreUpdatePayload{}, ImpactPayload{ObjectID: "loop-right"})
+	if !ok {
+		t.Fatal("expected loop-right to progress quest")
+	}
+
+	if state.ActiveQuests[0].Progress != 2 || !state.ActiveQuests[0].Completed {
+		t.Fatalf("expected loop quest completed, got %+v", state.ActiveQuests[0])
+	}
+}

--- a/backend/ws_hub.go
+++ b/backend/ws_hub.go
@@ -17,6 +17,7 @@ type Hub struct {
 	scorer     *ScoreTracker
 	boss       *BossTracker
 	player     *PlayerTracker
+	quests     *QuestTracker
 	mutex      sync.RWMutex
 }
 
@@ -37,6 +38,7 @@ func newHub() *Hub {
 		scorer:     newScoreTracker(defaultScoreConfig),
 		boss:       newBossTracker(defaultBossConfig),
 		player:     newPlayerTracker(defaultPlayerConfig),
+		quests:     newQuestTracker(),
 	}
 }
 

--- a/doc/Systeme_de_quetes.md
+++ b/doc/Systeme_de_quetes.md
@@ -198,10 +198,68 @@ Les éléments suivants existent déjà ou sont en bonne voie pour alimenter ce 
 
 ## Ce qu'il faudra encore ajouter
 
-Pour terminer le système de quêtes, il faudra ensuite :
+## État actuel d'intégration
 
-1. créer un `quest manager`
-2. tirer aléatoirement `3 quêtes actives`
-3. suivre leur progression
-4. envoyer un état type `quest_update`
-5. déclencher `boss_fight_started` quand les `3 quêtes` sont validées
+Une première version backend du système de quêtes est maintenant en place.
+
+Le backend :
+
+- possède un `QuestTracker` ;
+- utilise le pool initial de `9 quêtes` décrit dans ce document ;
+- tire `3 quêtes actives` au `start_game` ;
+- choisit `1 quête` par catégorie :
+  - `Score / progression`
+  - `Précision / maîtrise`
+  - `Exploration / survie`
+- envoie un message WebSocket `quest_update` ;
+- suit la progression des quêtes à partir des impacts et du score ;
+- déclenche automatiquement le boss fight quand les `3 quêtes actives` sont terminées.
+
+Le frontend affiche aussi les quêtes actives dans le HUD de test.
+
+### Message `quest_update`
+
+Exemple :
+
+```json
+{
+  "type": "quest_update",
+  "payload": {
+    "activeQuests": [
+      {
+        "id": "score_2000",
+        "category": "score",
+        "label": "Atteindre 2 000 points",
+        "target": 2000,
+        "progress": 500,
+        "completed": false
+      }
+    ],
+    "completedCount": 0,
+    "requiredCount": 3,
+    "allCompleted": false,
+    "bossFightTriggered": false,
+    "mode": "quest_progress"
+  }
+}
+```
+
+### Règle actuelle
+
+Les quêtes progressent uniquement tant que le boss fight n'est pas actif.
+
+Quand les `3 quêtes` sont terminées :
+
+1. le backend envoie un dernier `quest_update` avec `bossFightTriggered: true` ;
+2. le backend active le boss ;
+3. le backend envoie un `boss_state_update`.
+
+## Ce qu'il faudra encore améliorer
+
+Pour finaliser le système de quêtes, il faudra ensuite :
+
+1. améliorer l'affichage visuel des quêtes ;
+2. équilibrer les valeurs après des tests jouables ;
+3. relier les quêtes à la progression réelle des phases ;
+4. remplacer les éléments temporaires de test par les vrais événements gameplay ;
+5. gérer proprement le passage phase suivante / boss suivant.

--- a/frontend/flipper/ui/ScoreDisplay.js
+++ b/frontend/flipper/ui/ScoreDisplay.js
@@ -15,7 +15,11 @@ const DEFAULT_STATE = {
     playerMaxBalls: 0,
     playerLastDamageTaken: 0,
     playerLastBallLost: false,
-    gameOver: false
+    gameOver: false,
+    quests: [],
+    questsCompleted: 0,
+    questsRequired: 0,
+    questsDone: false
 };
 
 export class ScoreDisplay {
@@ -33,6 +37,7 @@ export class ScoreDisplay {
         this.playerValue = null;
         this.playerBallsValue = null;
         this.playerDetailValue = null;
+        this.questValue = null;
         this.controlsContainer = null;
         this.boundHandler = (event) => this.handleBackendEvent(event?.detail);
     }
@@ -49,7 +54,9 @@ export class ScoreDisplay {
             top: '24px',
             left: '24px',
             zIndex: '20',
-            minWidth: '220px',
+            width: '260px',
+            maxHeight: '86vh',
+            overflow: 'hidden',
             padding: '16px 18px',
             borderRadius: '14px',
             border: '1px solid rgba(98, 255, 168, 0.22)',
@@ -143,6 +150,19 @@ export class ScoreDisplay {
             opacity: '0.94'
         });
 
+        this.questValue = this.documentRef.createElement('div');
+        Object.assign(this.questValue.style, {
+            fontSize: '11px',
+            marginTop: '10px',
+            paddingTop: '10px',
+            borderTop: '1px solid rgba(126, 255, 179, 0.14)',
+            color: '#e7ffd0',
+            whiteSpace: 'pre-line',
+            overflowWrap: 'break-word',
+            maxHeight: '180px',
+            overflowY: 'auto'
+        });
+
         this.container.appendChild(title);
         this.container.appendChild(this.scoreValue);
         this.container.appendChild(this.comboValue);
@@ -153,6 +173,7 @@ export class ScoreDisplay {
         this.container.appendChild(this.playerValue);
         this.container.appendChild(this.playerBallsValue);
         this.container.appendChild(this.playerDetailValue);
+        this.container.appendChild(this.questValue);
         container.appendChild(this.container);
         this.mountControlsHelp(container);
 
@@ -274,6 +295,14 @@ export class ScoreDisplay {
                 playerLastBallLost: Boolean(message.payload.lastBallLost),
                 gameOver: Boolean(message.payload.gameOver)
             };
+        } else if (message.type === 'quest_update') {
+            this.state = {
+                ...this.state,
+                quests: Array.isArray(message.payload.activeQuests) ? message.payload.activeQuests : [],
+                questsCompleted: Number(message.payload.completedCount ?? 0),
+                questsRequired: Number(message.payload.requiredCount ?? 0),
+                questsDone: Boolean(message.payload.allCompleted)
+            };
         } else {
             return false;
         }
@@ -298,6 +327,7 @@ export class ScoreDisplay {
         this.playerValue.textContent = this.formatPlayerLabel();
         this.playerBallsValue.textContent = this.formatPlayerBalls();
         this.playerDetailValue.textContent = this.formatPlayerDetail();
+        this.questValue.textContent = this.formatQuests();
     }
 
     formatScore(value) {
@@ -360,5 +390,23 @@ export class ScoreDisplay {
         }
 
         return `Balles: ${this.state.playerBalls}/${this.state.playerMaxBalls}`;
+    }
+
+    formatQuests() {
+        if (!Array.isArray(this.state.quests) || this.state.quests.length === 0) {
+            return 'Quêtes: en attente';
+        }
+
+        const lines = [`Quêtes: ${this.state.questsCompleted}/${this.state.questsRequired}`];
+        for (const quest of this.state.quests) {
+            const status = quest.completed ? '✓' : '-';
+            lines.push(`${status} ${quest.label}: ${quest.progress}/${quest.target}`);
+        }
+
+        if (this.state.questsDone) {
+            lines.push('Boss débloqué');
+        }
+
+        return lines.join('\n');
     }
 }

--- a/tests/frontend/score-display.test.js
+++ b/tests/frontend/score-display.test.js
@@ -49,6 +49,7 @@ test('ScoreDisplay mounts with default values', () => {
   assert.equal(display.playerValue.textContent, 'Joueur: en attente');
   assert.equal(display.playerBallsValue.textContent, 'Balles: --');
   assert.equal(display.playerDetailValue.textContent, 'État joueur: --');
+  assert.equal(display.questValue.textContent, 'Quêtes: en attente');
   assert.equal(display.controlsContainer.children[0].textContent, 'CONTRÔLES');
 });
 
@@ -97,6 +98,34 @@ test('ScoreDisplay updates its fields when receiving score_update', () => {
   assert.equal(display.comboValue.textContent, 'Combo x3');
   assert.equal(display.deltaValue.textContent, '+225');
   assert.equal(display.detailValue.textContent, 'Dernier impact: launching_ramp_rail');
+});
+
+test('ScoreDisplay updates quest state when receiving quest_update', () => {
+  const documentRef = createFakeDocument();
+  const display = new ScoreDisplay({ documentRef, eventTarget: null });
+  display.mount();
+
+  const handled = display.handleBackendEvent({
+    type: 'quest_update',
+    payload: {
+      completedCount: 1,
+      requiredCount: 3,
+      allCompleted: false,
+      activeQuests: [
+        {
+          id: 'score_2000',
+          label: 'Atteindre 2 000 points',
+          target: 2000,
+          progress: 2000,
+          completed: true
+        }
+      ]
+    }
+  });
+
+  assert.equal(handled, true);
+  assert.equal(display.questValue.textContent.includes('Quêtes: 1/3'), true);
+  assert.equal(display.questValue.textContent.includes('✓ Atteindre 2 000 points: 2000/2000'), true);
 });
 
 test('ScoreDisplay updates boss state when receiving boss_state_update', () => {


### PR DESCRIPTION
## Contexte

Cette PR ajoute le système de quêtes aléatoires afin de préparer l’apparition du boss après la validation de 3 objectifs de gameplay.

Closes #117

## Travail réalisé

- création d’un pool de 9 quêtes réparties en 3 catégories ;
- tirage aléatoire d’une quête par catégorie au lancement d’une partie ;
- suivi de la progression des quêtes à partir des événements de gameplay ;
- envoi d’un message WebSocket `quest_update` vers le frontend ;
- affichage des quêtes dans le HUD ;
- déclenchement automatique du boss fight lorsque les 3 quêtes sont terminées ;
- mise à jour des tests et de la documentation liés aux quêtes.

## Note

Les modifications temporaires du playfield utilisées uniquement pour les tests manuels ne font pas partie de cette PR.
