### PR TITLE
Gameplay : Ajustement des points et des zones d’impact

### DIFF
--- a/backend/boss.go
+++ b/backend/boss.go
@@ -3,8 +3,8 @@ package main
 import "sync"
 
 const (
-	defaultBossMaxHP        = 1000
-	defaultBossDamageFactor = 0.10
+	defaultBossMaxHP        = 1500
+	defaultBossDamageFactor = 0.05
 )
 
 type BossStateUpdatePayload struct {

--- a/backend/game_service.go
+++ b/backend/game_service.go
@@ -157,7 +157,14 @@ func (gs *GameService) handleBossFightToggled() {
 // handlePlayerDamageTest simule une attaque du boss tant que les vraies attaques ne sont pas branchées
 func (gs *GameService) handlePlayerDamageTest() {
 	log.Println("Dégâts joueur test")
-	gs.hub.broadcast <- NewPlayerStateUpdateMessage(gs.hub.player.ApplyDamage(defaultBossAttackDamage))
+	playerUpdate := gs.hub.player.ApplyDamage(defaultBossAttackDamage)
+	gs.hub.broadcast <- NewPlayerStateUpdateMessage(playerUpdate)
+
+	if playerUpdate.LastBallLost {
+		if questUpdate, ok := gs.hub.quests.ResetSurvivalQuestForNewBall(time.Now().UnixMilli()); ok {
+			gs.hub.broadcast <- NewQuestUpdateMessage(questUpdate)
+		}
+	}
 }
 
 // handleBallLost simule une perte de balle

--- a/backend/game_service_test.go
+++ b/backend/game_service_test.go
@@ -277,6 +277,76 @@ func TestGameServiceHandlePlayerDamageTest(t *testing.T) {
 	}
 }
 
+func TestGameServiceResetsSurvivalQuestWhenBossDamageLosesBall(t *testing.T) {
+	hub := newHub()
+	hub.player = newPlayerTracker(PlayerConfig{MaxHP: 20, MaxBalls: 3})
+	hub.quests.activeQuests = []Quest{
+		{ID: "survive_20s", Category: "exploration", Label: "Survivre 20 secondes avec la même bille", Target: 20, Progress: 8},
+	}
+	hub.quests.phaseStartedAt = time.Now().Add(-8 * time.Second).UnixMilli()
+	go hub.run()
+
+	client := &Client{send: make(chan []byte, 256)}
+	hub.register <- client
+
+	service := NewGameService(hub)
+
+	msg := Message{Type: "boss_attack_test"}
+	response, isDirectResponse := service.HandleMessage(msg, []byte(`{"type":"boss_attack_test"}`))
+
+	if isDirectResponse {
+		t.Fatal("expected boss_attack_test to not return a direct response")
+	}
+
+	if response != nil {
+		t.Fatal("expected nil response for boss_attack_test")
+	}
+
+	messages := make([]Message, 0)
+	timeout := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(timeout) && len(messages) < 2 {
+		select {
+		case broadcast := <-client.send:
+			var msgResp Message
+			if err := json.Unmarshal(broadcast, &msgResp); err != nil {
+				t.Fatalf("failed to unmarshal broadcast: %v", err)
+			}
+			messages = append(messages, msgResp)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if len(messages) < 2 {
+		t.Fatalf("expected player_state_update and quest_update, got %d messages", len(messages))
+	}
+
+	if messages[0].Type != "player_state_update" {
+		t.Fatalf("expected first message player_state_update, got %s", messages[0].Type)
+	}
+
+	var playerPayload PlayerStateUpdatePayload
+	if err := json.Unmarshal(messages[0].Payload, &playerPayload); err != nil {
+		t.Fatalf("failed to unmarshal player payload: %v", err)
+	}
+
+	if !playerPayload.LastBallLost || playerPayload.Balls != 2 {
+		t.Fatalf("expected ball lost after boss damage, got %+v", playerPayload)
+	}
+
+	if messages[1].Type != "quest_update" {
+		t.Fatalf("expected second message quest_update, got %s", messages[1].Type)
+	}
+
+	var questPayload QuestUpdatePayload
+	if err := json.Unmarshal(messages[1].Payload, &questPayload); err != nil {
+		t.Fatalf("failed to unmarshal quest payload: %v", err)
+	}
+
+	if len(questPayload.ActiveQuests) != 1 || questPayload.ActiveQuests[0].Progress != 0 {
+		t.Fatalf("expected survival quest reset, got %+v", questPayload)
+	}
+}
+
 func TestGameServiceHandleBossFightStarted(t *testing.T) {
 	hub := newHub()
 	hub.boss = newBossTracker(defaultBossConfig)

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -290,8 +290,8 @@ func TestWebSocketBroadcastsScoreUpdateAfterImpact(t *testing.T) {
 		t.Fatalf("failed to unmarshal score update payload: %v", err)
 	}
 
-	if payload.Score != 50 || payload.Delta != 50 {
-		t.Fatalf("expected score update to report 50 points, got score=%d delta=%d", payload.Score, payload.Delta)
+	if payload.Score != 25 || payload.Delta != 25 {
+		t.Fatalf("expected score update to report 25 points, got score=%d delta=%d", payload.Score, payload.Delta)
 	}
 	if payload.ComboCount != 1 || payload.ComboMultiplier != 1 {
 		t.Fatalf("expected first hit combo to be x1, got combo=%d multiplier=%d", payload.ComboCount, payload.ComboMultiplier)
@@ -431,8 +431,8 @@ func TestWebSocketBroadcastsBossStateUpdateAfterImpactWhileBossIsActive(t *testi
 		t.Fatalf("failed to unmarshal boss state payload: %v", err)
 	}
 
-	if payload.HP != 995 || payload.DamageTaken != 5 || !payload.Active {
-		t.Fatalf("expected 5 damage on active boss, got %+v", payload)
+	if payload.HP != 1499 || payload.DamageTaken != 1 || !payload.Active {
+		t.Fatalf("expected 1 damage on active boss, got %+v", payload)
 	}
 }
 

--- a/backend/score.go
+++ b/backend/score.go
@@ -9,9 +9,9 @@ import (
 const (
 	defaultComboWindow     = 2 * time.Second
 	defaultMultiplierReset = 3 * time.Second
-	loopBasePoints         = 300
-	loopMaxPoints          = 800
-	superRampComboBonus    = 2000
+	loopBasePoints         = 120
+	loopMaxPoints          = 350
+	superRampComboBonus    = 700
 )
 
 type ScoreUpdatePayload struct {
@@ -163,35 +163,35 @@ func (s *ScoreTracker) basePointsForImpact(objectType, objectID string) int {
 	switch objectType {
 	case "bumper":
 		if s.comboCount >= 2 {
+			return 40
+		}
+		return 25
+	case "target":
+		if containsAny(objectID, "center", "centre", "precise", "precision") {
 			return 75
 		}
 		return 50
-	case "target":
-		if containsAny(objectID, "center", "centre", "precise", "precision") {
-			return 150
-		}
-		return 100
 	case "launching_ramp", "ramp":
 		if containsAny(objectID, "perfect", "parfait", "clean", "sans-rebond") {
-			return 750
+			return 350
 		}
-		return 500
+		return 200
 	case "launching_ramp_rail", "rail", "loop", "lane":
 		return s.loopPoints(objectID)
 	case "star", "star_zone", "etoile", "étoile":
 		if containsAny(objectID, "center", "centre", "exact") {
-			return 1000
+			return 400
 		}
 		if containsAny(objectID, "outer", "edge", "ext") {
-			return 100
+			return 50
 		}
-		return 500
+		return 200
 	case "wall":
-		return 25
+		return 0
 	case "portal":
-		return 300
+		return 150
 	case "saucer":
-		return 500
+		return 200
 	case "palle", "ball", "":
 		return 0
 	default:
@@ -203,7 +203,7 @@ func (s *ScoreTracker) loopPoints(objectID string) int {
 	streak := s.loopStreakByID[objectID] + 1
 	s.loopStreakByID[objectID] = streak
 
-	scaled := loopBasePoints + ((streak - 1) * 250)
+	scaled := loopBasePoints + ((streak - 1) * 80)
 	if scaled > loopMaxPoints {
 		return loopMaxPoints
 	}
@@ -234,13 +234,13 @@ func (s *ScoreTracker) registerRecentType(objectType string) bool {
 func comboBonusForCount(comboCount int) int {
 	switch {
 	case comboCount >= 5:
-		return 1000
+		return 400
 	case comboCount == 4:
-		return 700
+		return 250
 	case comboCount == 3:
-		return 300
+		return 120
 	case comboCount == 2:
-		return 100
+		return 50
 	default:
 		return 0
 	}
@@ -248,11 +248,11 @@ func comboBonusForCount(comboCount int) int {
 
 func multiplierForHitStreak(hitStreak int) int {
 	switch {
-	case hitStreak >= 10:
+	case hitStreak >= 18:
 		return 4
-	case hitStreak >= 6:
+	case hitStreak >= 12:
 		return 3
-	case hitStreak >= 3:
+	case hitStreak >= 6:
 		return 2
 	default:
 		return 1

--- a/backend/score_test.go
+++ b/backend/score_test.go
@@ -17,8 +17,8 @@ func TestScoreTrackerUsesNewBumperComboValues(t *testing.T) {
 		t.Fatal("expected first impact to generate score")
 	}
 
-	if first.BasePoints != 50 || first.Delta != 50 || first.Score != 50 {
-		t.Fatalf("expected first bumper hit to add 50 points, got %+v", first)
+	if first.BasePoints != 25 || first.Delta != 25 || first.Score != 25 {
+		t.Fatalf("expected first bumper hit to add 25 points, got %+v", first)
 	}
 	if first.ComboBonus != 0 || first.ComboMultiplier != 1 {
 		t.Fatalf("expected no combo bonus and x1 multiplier on first hit, got %+v", first)
@@ -33,14 +33,14 @@ func TestScoreTrackerUsesNewBumperComboValues(t *testing.T) {
 		t.Fatal("expected second impact to generate score")
 	}
 
-	if second.BasePoints != 75 {
-		t.Fatalf("expected combo bumper hit to use 75 base points, got %d", second.BasePoints)
+	if second.BasePoints != 40 {
+		t.Fatalf("expected combo bumper hit to use 40 base points, got %d", second.BasePoints)
 	}
-	if second.ComboBonus != 100 || second.ComboMultiplier != 1 {
-		t.Fatalf("expected second hit to get +100 combo bonus and x1 multiplier, got %+v", second)
+	if second.ComboBonus != 50 || second.ComboMultiplier != 1 {
+		t.Fatalf("expected second hit to get +50 combo bonus and x1 multiplier, got %+v", second)
 	}
-	if second.Delta != 175 || second.Score != 225 {
-		t.Fatalf("expected second hit to add 175 and total 225, got %+v", second)
+	if second.Delta != 90 || second.Score != 115 {
+		t.Fatalf("expected second hit to add 90 and total 115, got %+v", second)
 	}
 }
 
@@ -54,6 +54,12 @@ func TestScoreTrackerAppliesGlobalMultiplierThresholds(t *testing.T) {
 		{ObjectID: "target-right", ObjectType: "target", Timestamp: 2_500},
 		{ObjectID: "loop-left", ObjectType: "lane", Timestamp: 3_000},
 		{ObjectID: "loop-right", ObjectType: "lane", Timestamp: 3_500},
+		{ObjectID: "bumper-1", ObjectType: "bumper", Timestamp: 4_000},
+		{ObjectID: "bumper-2", ObjectType: "bumper", Timestamp: 4_500},
+		{ObjectID: "target-left", ObjectType: "target", Timestamp: 5_000},
+		{ObjectID: "target-right", ObjectType: "target", Timestamp: 5_500},
+		{ObjectID: "loop-left", ObjectType: "lane", Timestamp: 6_000},
+		{ObjectID: "loop-right", ObjectType: "lane", Timestamp: 6_500},
 	}
 
 	var last ScoreUpdatePayload
@@ -66,7 +72,7 @@ func TestScoreTrackerAppliesGlobalMultiplierThresholds(t *testing.T) {
 	}
 
 	if last.ComboMultiplier != 3 || last.GlobalMultiplier != 3 {
-		t.Fatalf("expected 6-hit streak to reach x3 multiplier, got %+v", last)
+		t.Fatalf("expected 12-hit streak to reach x3 multiplier, got %+v", last)
 	}
 }
 
@@ -112,8 +118,8 @@ func TestScoreTrackerSupportsLoopScalingAndSuperRampCombo(t *testing.T) {
 	if !ok {
 		t.Fatal("expected first loop to generate score")
 	}
-	if firstLoop.BasePoints != 300 {
-		t.Fatalf("expected first loop to start at 300, got %+v", firstLoop)
+	if firstLoop.BasePoints != 120 {
+		t.Fatalf("expected first loop to start at 120, got %+v", firstLoop)
 	}
 
 	secondLoop, ok := tracker.ApplyImpact(ImpactPayload{ObjectID: "loop-left", ObjectType: "lane", Timestamp: 1_500})
@@ -144,7 +150,7 @@ func TestScoreTrackerSupportsLoopScalingAndSuperRampCombo(t *testing.T) {
 	if !thirdRamp.SuperCombo {
 		t.Fatalf("expected third ramp hit to trigger super combo, got %+v", thirdRamp)
 	}
-	if thirdRamp.ComboBonus < 2300 {
+	if thirdRamp.ComboBonus < 820 {
 		t.Fatalf("expected third ramp hit to include standard combo bonus plus super combo bonus, got %+v", thirdRamp)
 	}
 }
@@ -154,6 +160,14 @@ func TestScoreTrackerIgnoresZeroPointImpacts(t *testing.T) {
 
 	if _, ok := tracker.ApplyImpact(ImpactPayload{ObjectID: "palle-left", ObjectType: "palle", Timestamp: 1_000}); ok {
 		t.Fatal("expected palle impact to be ignored for scoring")
+	}
+
+	if _, ok := tracker.ApplyImpact(ImpactPayload{ObjectID: "wall-1", ObjectType: "wall", Timestamp: 2_000}); ok {
+		t.Fatal("expected wall impact to be ignored for scoring")
+	}
+
+	if _, ok := tracker.ApplyImpact(ImpactPayload{ObjectID: "ground", ObjectType: "ground", Timestamp: 3_000}); ok {
+		t.Fatal("expected ground impact to be ignored for scoring")
 	}
 }
 

--- a/doc/Regle_de_score.md
+++ b/doc/Regle_de_score.md
@@ -20,36 +20,45 @@ Ordre de priorité gameplay :
 
 ### Bumpers (centraux)
 
-- hit simple : `+50 pts`
-- hit en combo : `+75 pts`
+- hit simple : `+25 pts`
+- hit en combo : `+40 pts`
 
 ### Cibles (targets basses gauche/droite)
 
-- hit simple : `+100 pts`
-- hit précis (centre) : `+150 pts`
+- hit simple : `+50 pts`
+- hit précis (centre) : `+75 pts`
 
 ### Rampes (gauche / droite)
 
-- passage simple : `+500 pts`
-- passage parfait (sans rebond) : `+750 pts`
+- passage simple : `+200 pts`
+- passage parfait (sans rebond) : `+350 pts`
 
 ### Zone étoiles (centre bas)
 
-- score variable : `100 → 1000 pts`
-- centre exact : `+1000 pts`
-- activation complète : `+3000 pts bonus`
+- score variable : `50 → 400 pts`
+- centre exact : `+400 pts`
+- activation complète : `+1200 pts bonus`
 
 ### Boucles / rails supérieurs
 
-- passage complet : `+300 pts`
-- enchaînement loop repeat : `+300 → 800 pts` avec scaling
+- passage complet : `+120 pts`
+- enchaînement loop repeat : `+120 → 350 pts` avec scaling
+
+### Éléments sans score
+
+- murs / bordures : `0 pt`
+- sol / ground : `0 pt`
+- balle : `0 pt`
+- palles : `0 pt`
+
+Ces éléments peuvent générer des collisions physiques, mais ils ne doivent pas augmenter le score.
 
 ## Multiplicateur global
 
 - base : `x1`
-- `3 hits` consécutifs : `x2`
-- `6 hits` : `x3`
-- `10 hits` : `x4` maximum
+- `6 hits` consécutifs : `x2`
+- `12 hits` : `x3`
+- `18 hits` : `x4` maximum
 
 ### Reset du multiplicateur
 
@@ -66,14 +75,14 @@ Ordre de priorité gameplay :
 
 | Combo | Bonus |
 |-------|-------|
-| x2 | `+100 pts` |
-| x3 | `+300 pts` |
-| x4 | `+700 pts` |
-| x5+ | `+1000 pts` |
+| x2 | `+50 pts` |
+| x3 | `+120 pts` |
+| x4 | `+250 pts` |
+| x5+ | `+400 pts` |
 
 ### Bonus spécial
 
-- `Rampe → Rampe → Rampe` : `+2000 pts` (`Super combo`)
+- `Rampe → Rampe → Rampe` : `+700 pts` (`Super combo`)
 
 ## Objectifs / progression
 
@@ -93,7 +102,7 @@ Ordre de priorité gameplay :
 ### Objectif cibles basses
 
 - toutes les cibles activées :
-  - bonus immédiat : `+1500 pts`
+  - bonus immédiat : `+750 pts`
   - réinitialisation des cibles
 
 ## Bonus dynamiques
@@ -106,7 +115,7 @@ Ordre de priorité gameplay :
 
 ### Skill Shot
 
-- tir précis au lancement : `+2000 pts`
+- tir précis au lancement : `+800 pts`
 
 ## État actuel du backend
 
@@ -133,15 +142,15 @@ Dégâts boss = Delta de score × coefficient
 
 ### Valeur temporaire utilisée
 
-- coefficient actuel : `0.10`
+- coefficient actuel : `0.05`
 - exemple :
-  - `+50 pts` => `5 dégâts boss`
-  - `+750 pts` => `75 dégâts boss`
+  - `+25 pts` => `1 dégât boss`
+  - `+350 pts` => `17 dégâts boss`
 
 ### État actuel d'intégration
 
 - le backend maintient un état minimal du boss ;
-- le boss possède `1000 HP` maximum ;
+- le boss possède `1500 HP` maximum ;
 - un message `boss_state_update` est renvoyé au frontend ;
 - au `start_game`, le boss est réinitialisé mais reste `inactif` ;
 - pour les tests, le boss peut être activé ou désactivé manuellement.
@@ -196,11 +205,11 @@ Pendant les tests, le frontend peut aussi envoyer :
 {
   "type": "score_update",
   "payload": {
-    "score": 225,
-    "delta": 175,
-    "basePoints": 75,
+    "score": 115,
+    "delta": 90,
+    "basePoints": 40,
     "comboCount": 2,
-    "comboBonus": 100,
+    "comboBonus": 50,
     "comboMultiplier": 1,
     "globalMultiplier": 1,
     "superCombo": false,
@@ -217,10 +226,10 @@ Pendant les tests, le frontend peut aussi envoyer :
   "type": "boss_state_update",
   "payload": {
     "active": true,
-    "hp": 925,
-    "maxHp": 1000,
-    "damageTaken": 75,
-    "coefficient": 0.1,
+    "hp": 1483,
+    "maxHp": 1500,
+    "damageTaken": 17,
+    "coefficient": 0.05,
     "defeated": false,
     "mode": "score_damage"
   }

--- a/doc/Specifications_3_ecrans.md
+++ b/doc/Specifications_3_ecrans.md
@@ -1,0 +1,222 @@
+# Spécifications des 3 écrans du flipper
+
+## Contexte
+
+Ce document regroupe les spécifications techniques observées sur les écrans de debug du flipper physique.
+
+Le projet utilise trois écrans distincts :
+
+- `Backglass` : écran supérieur principal ;
+- `DMD` : écran central plus petit pour les informations de jeu ;
+- `Playfield` : écran principal incliné du plateau de jeu.
+
+Ces informations servent de référence pour adapter l'affichage frontend aux dimensions réelles de la machine.
+
+## Résumé
+
+| Écran | Rôle | Résolution viewport | Résolution display | Ratio | Source kiosk |
+|---|---|---:|---:|---:|---|
+| Backglass | Écran supérieur | 1920 x 1080 px | 1920 x 1080 px | 1.778 (16:9) | `localhost:32789/?screen=backglass` |
+| DMD | Écran central | 1920 x 1080 px | 1920 x 1080 px | 1.778 (16:9) | `localhost:32789/?screen=dmd` |
+| Playfield | Plateau principal | 2160 x 3840 px | 2160 x 3840 px | 0.563 (9:16) | `localhost:32789/?screen=playfield` |
+
+## Spécifications communes
+
+Les informations suivantes sont communes aux écrans observés :
+
+```text
+Pixel ratio : 1.00
+Color depth : 24-bit
+Flipper IP  : 100.125.185.88
+Dashboard   : http://100.125.185.88:8080
+Network     : ONLINE
+Browser     : Chrome 148
+```
+
+## Écran Backglass
+
+### Rôle
+
+```text
+BACKGLASS
+```
+
+Le Backglass correspond à l'écran supérieur principal du flipper.
+
+Il est destiné à afficher les éléments visuels importants liés à l'univers du jeu, par exemple :
+
+- le boss de la phase ;
+- les animations narratives ;
+- les effets visuels de phase ;
+- l'ambiance générale du monde actif.
+
+### Spécifications observées
+
+```text
+Viewport    : 1920 x 1080 px
+Display     : 1920 x 1080 px
+Aspect      : 1.778 (16:9)
+Pixel ratio : 1.00
+Color depth : 24-bit
+Kiosk src   : localhost:32789/?screen=backglass
+```
+
+### Notes d'intégration
+
+L'affichage doit être pensé en format paysage `16:9`.
+
+Le contenu important ne doit pas être collé aux bords, car l'écran est intégré dans le meuble du flipper et peut avoir des zones visuellement moins confortables près du cadre.
+
+## Écran DMD
+
+### Rôle
+
+```text
+DMD
+```
+
+Le DMD correspond à l'écran central situé entre le Backglass et le Playfield.
+
+Dans notre gameplay, il sert à afficher les informations courtes et directement utiles pendant la partie.
+
+Exemples d'informations prévues :
+
+- score ;
+- série de combo ;
+- multiplicateur ;
+- balles restantes ;
+- quêtes actives ;
+- HP du boss ;
+- HP du joueur.
+
+### Spécifications observées
+
+```text
+Viewport    : 1920 x 1080 px
+Display     : 1920 x 1080 px
+Aspect      : 1.778 (16:9)
+Pixel ratio : 1.00
+Color depth : 24-bit
+Kiosk src   : localhost:32789/?screen=dmd
+```
+
+### Notes d'intégration
+
+Même si la résolution observée est `1920 x 1080 px`, le DMD est physiquement plus petit que le Backglass.
+
+Il faut donc éviter les textes trop longs.
+
+Recommandations :
+
+- utiliser des informations courtes ;
+- limiter le nombre de lignes affichées ;
+- privilégier les labels simples ;
+- éviter les phrases longues pendant le gameplay ;
+- utiliser une typographie très lisible ;
+- garder un contraste fort.
+
+Exemple de structure adaptée :
+
+```text
+SCORE 12 500
+SÉRIE +600            MULT x2
+BALLES 3/3
+```
+
+Ou, pour les quêtes :
+
+```text
+QUÊTES 1/3
+✓ Points 2000/2000
+- Rampe parfaite 0/1
+- Survivre 20s 8/20s
+```
+
+## Écran Playfield
+
+### Rôle
+
+```text
+PLAYFIELD
+```
+
+Le Playfield correspond à l'écran principal incliné du flipper.
+
+C'est l'écran sur lequel le joueur voit le plateau de jeu, la bille, les flippers, les bumpers, les rampes et les zones d'impact.
+
+### Spécifications observées
+
+```text
+Viewport    : 2160 x 3840 px
+Display     : 2160 x 3840 px
+Aspect      : 0.563 (9:16)
+Pixel ratio : 1.00
+Color depth : 24-bit
+Kiosk src   : localhost:32789/?screen=playfield
+```
+
+### Notes d'intégration
+
+L'affichage doit être pensé en format portrait `9:16`.
+
+C'est l'écran principal de gameplay. Il doit donc rester prioritaire pour :
+
+- la lisibilité de la bille ;
+- la lisibilité des obstacles ;
+- la compréhension des zones d'impact ;
+- les rampes et couloirs ;
+- les effets visuels liés au score et aux quêtes.
+
+Les informations de HUD doivent être limitées sur cet écran pour ne pas cacher le plateau.
+
+## Répartition fonctionnelle recommandée
+
+| Écran | Contenu principal recommandé |
+|---|---|
+| Backglass | Boss, ambiance de phase, animations narratives, effets spectaculaires |
+| DMD | Score, combo, quêtes, balles, HP joueur, HP boss |
+| Playfield | Plateau jouable, bille, flippers, bumpers, rampes, targets, portails |
+
+## URLs locales observées
+
+```text
+Backglass : localhost:32789/?screen=backglass
+DMD       : localhost:32789/?screen=dmd
+Playfield : localhost:32789/?screen=playfield
+```
+
+## Dashboard
+
+Le dashboard de contrôle observé est disponible à l'adresse suivante :
+
+```text
+http://100.125.185.88:8080
+```
+
+## Points d'attention
+
+- Les trois écrans utilisent Chrome `148` d'après les écrans de debug.
+- Le pixel ratio observé est `1.00`, donc les dimensions CSS peuvent être pensées directement en pixels logiques.
+- Le Playfield est en portrait, contrairement au Backglass et au DMD qui sont en paysage.
+- Le DMD possède la même résolution observée que le Backglass, mais il doit rester traité comme une zone d'information compacte.
+- Le frontend doit pouvoir différencier les écrans via le paramètre `screen` dans l'URL.
+
+## Impact pour le développement frontend
+
+Le frontend doit pouvoir adapter son rendu selon :
+
+```text
+?screen=backglass
+?screen=dmd
+?screen=playfield
+```
+
+Cela permet d'avoir une interface spécifique à chaque écran au lieu d'afficher le même contenu partout.
+
+À terme, chaque écran devrait avoir son propre rôle :
+
+```text
+Backglass -> écran boss / narration
+DMD       -> écran score / état de partie
+Playfield -> écran gameplay principal
+```

--- a/doc/Systeme_boss_fight_player_state.md
+++ b/doc/Systeme_boss_fight_player_state.md
@@ -21,7 +21,7 @@ Le systeme doit permettre de :
 
 ### Boss
 
-- PV maximum du boss : `1000 HP`
+- PV maximum du boss : `1500 HP`
 - Le boss commence inactif au debut d'une partie.
 - Le boss devient actif quand le boss fight est declenche.
 - Pour les tests actuels, le boss peut etre active manuellement.
@@ -48,18 +48,18 @@ Degats boss = Delta de score x coefficient de degats
 Valeur recommandee pour le MVP :
 
 ```text
-coefficient de degats = 0.10
+coefficient de degats = 0.05
 ```
 
 Exemples :
 
 | Action | Delta de score | Degats boss |
 |--------|----------------|-------------|
-| Bumper simple | `+50 pts` | `5 degats` |
-| Cible simple | `+100 pts` | `10 degats` |
-| Rampe simple | `+500 pts` | `50 degats` |
-| Rampe parfaite | `+750 pts` | `75 degats` |
-| Super combo rampe | `+2000 pts` bonus | `200 degats` bonus |
+| Bumper simple | `+25 pts` | `1 degat` |
+| Cible simple | `+50 pts` | `2 degats` |
+| Rampe simple | `+200 pts` | `10 degats` |
+| Rampe parfaite | `+350 pts` | `17 degats` |
+| Super combo rampe | `+700 pts` bonus | `35 degats` bonus |
 
 Cette regle permet de recompenser directement les actions fortes du joueur : plus le joueur marque de points pendant le boss fight, plus il inflige de degats.
 
@@ -111,10 +111,10 @@ Message deja existant :
   "type": "boss_state_update",
   "payload": {
     "active": true,
-    "hp": 925,
-    "maxHp": 1000,
-    "damageTaken": 75,
-    "coefficient": 0.1,
+    "hp": 1483,
+    "maxHp": 1500,
+    "damageTaken": 17,
+    "coefficient": 0.05,
     "defeated": false,
     "mode": "score_damage"
   }
@@ -171,11 +171,11 @@ Ces touches sont temporaires et servent uniquement au debug gameplay.
 Le premier equilibrage recommande est :
 
 ```text
-Boss HP: 1000
+Boss HP: 1500
 Player HP: 100
 Balles / vies: 3
 Degats boss vers joueur: 20
-Degats joueur vers boss: score_delta x 0.10
+Degats joueur vers boss: score_delta x 0.05
 ```
 
 Ce reglage donne une base lisible :
@@ -190,7 +190,7 @@ Ce reglage donne une base lisible :
 Apres integration et tests, il faudra probablement ajuster :
 
 - les PV du boss selon la duree moyenne d'une phase ;
-- le coefficient de degats `0.10` si le boss tombe trop vite ou trop lentement ;
+- le coefficient de degats `0.05` si le boss tombe trop vite ou trop lentement ;
 - les degats du boss selon la frequence des attaques ;
 - le nombre de balles si le jeu devient trop facile ou trop punitif ;
 - les recompenses apres chaque boss de phase.


### PR DESCRIPTION
## Contexte

Cette PR ajuste l’équilibrage du score et les zones d’impact afin de rendre la progression plus contrôlée et le boss fight plus long.

Closes #142

## Travail réalisé

- réduction des points gagnés sur les principaux éléments du plateau ;
- réduction des bonus de combo et du super combo rampe ;
- multiplicateurs rendus plus difficiles à obtenir ;
- suppression du score sur les éléments non gameplay comme les murs, le sol, la balle et les palles ;
- augmentation des PV du boss à `1500 HP` ;
- réduction du coefficient de dégâts infligés au boss à `score_delta x 0.05` ;
- correction de la quête `Survivre 20s` lorsque le joueur perd une balle après avoir perdu tous ses PV ;
- ajout d’une documentation des spécifications des trois écrans ;
- mise à jour de la documentation du score et du boss fight ;
- mise à jour des tests backend.
