### PR TITLE
Hardware : lancement automatique Linux et contrôleur ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,15 @@ Participants :
 - Communnication par le moyen de Websocket (communication avec TCP ouverture continu)
 - ESP32 avec serveur Moquitto
 
+## Lancement sur le flipper physique
+
+Pour la machine Linux du flipper physique, un script de lancement démarre les
+services Docker, le daemon ESP32 et le navigateur du playfield.
+
+Documentation :
+
+```text
+doc/Linux_Launcher_Flipper.md
+```
 
 Organisation sur la base d'un Gitflow

--- a/doc/Hardware_Architecture.md
+++ b/doc/Hardware_Architecture.md
@@ -14,7 +14,7 @@
 | IoT | Rôle | Matériel |
 |-----|------|----------|
 | **IoT 1** | Retour haptique (solénoïdes) | 2× ESP32 + 2× modules relais + 10 solénoïdes |
-| **IoT 2** | Contrôleur joueur + Tilt | 1× ESP32 + 8 boutons + 1 tirette analogique + 1× MPU-6050 |
+| **IoT 2** | Contrôleur joueur + Tilt | 1× ESP32 + 8 boutons + 1 plunger bouton + 1× MPU-6050 |
 
 **Flux de données :**
 
@@ -194,12 +194,12 @@ L'ESP32 Contrôleur est connecté au PC du Playfield par **câble USB** et trans
                     ┌──────────────────────────────┐
                     │         FACE AVANT            │
                     │                               │
-                    │   [Bouton 5]  [Bouton 6]  [Bouton 7]   ← 3 boutons face
-                    │    (Start)   (à définir) (à définir)     (usage futur)
+                    │ [Green] [Yellow] [Red] [White] ← boutons face
+                    │ (Green) (Face 2) (Face 3) (Jeton)
                     │                               │
                     │                         ║═══║ │
-                    │                         ║ T ║ ← Tirette (plunger)
-                    │                         ║ I ║   analogique 0→1
+                    │                         ║ T ║ ← Plunger
+                    │                         ║ I ║   bouton de lancement
                     │                         ║ R ║
   CÔTÉ GAUCHE       │                         ║═══║ │       CÔTÉ DROIT
   ┌────────┐        │                               │        ┌────────┐
@@ -221,24 +221,22 @@ L'ESP32 Contrôleur est connecté au PC du Playfield par **câble USB** et trans
 
 | # | Position | Bouton | Touche simulée | Type |
 |---|----------|--------|----------------|------|
-| 1 | Côté gauche | Flipper Gauche | `X` | Digital |
-| 2 | Côté gauche | Bouton Gauche 2 | à définir | Digital |
-| 3 | Côté droit | Flipper Droit | `C` | Digital |
-| 4 | Côté droit | Bouton Droit 2 | à définir | Digital |
-| 5 | Face avant | Start | `D` | Digital |
-| 6 | Face avant | Bouton Face 2 | à définir | Digital |
-| 7 | Face avant | Bouton Face 3 | à définir | Digital |
-| 8 | Mécanisme | Jeton / Pièce | `F` | Digital |
+| 1 | Côté gauche | button white left | `X` | Digital |
+| 2 | Côté gauche | button black left | `A` | Digital |
+| 3 | Côté droit | button white right | `C` | Digital |
+| 4 | Côté droit | button black right | `E` | Digital |
+| 5 | Face avant | button front left green | `G` | Digital |
+| 6 | Face avant | button front left yellow | `B` | Digital |
+| 7 | Face avant | button front left red | `H` | Digital |
+| 8 | Face avant | button front white | `F` | Digital |
 
-**1 entrée analogique (0.0 → 1.0) :**
+**1 entrée plunger :**
 
 | # | Position | Composant | Valeur | Type |
 |---|----------|-----------|--------|------|
-| 9 | Côté droit | Tirette (plunger) | 0.0 (repos) → 1.0 (tiré à fond) | Analogique |
+| 9 | Côté droit | plunger | appui maintenu → force de lancement, touche `D` simulée | Digital |
 
-La tirette utilise un **potentiomètre linéaire** qui renvoie une tension proportionnelle à la course de tirage. L'ESP32 lit cette tension via son convertisseur **ADC (Analog-to-Digital)**.
-
-**Contrainte technique ADC :** Le module ADC2 de l'ESP32 **ne fonctionne pas quand le Wi-Fi est actif**. La tirette doit obligatoirement être branchée sur un pin **ADC1** (GPIO 32, 33, 34, 35, 36 ou 39).
+Le plunger est lu comme un bouton. Plus l'appui dure longtemps, plus le jeu augmente la force de lancement de la bille.
 
 ### Capteur Tilt — MPU-6050
 
@@ -354,26 +352,21 @@ Le MPU-6050 communique en **I2C** avec l'ESP32 (2 fils seulement). Les événeme
   │        (Contrôleur)           │
   │                               │
   │  ── BOUTONS CÔTÉ GAUCHE ──   │
-  │  GPIO 12 ─────────────────────┼──── Bouton 1 : Flipper Gauche ──── GND
-  │  GPIO 14 ─────────────────────┼──── Bouton 2 : Gauche 2       ──── GND
+  │  GPIO 4  ─────────────────────┼──── button white left  ─────── GND
+  │  GPIO 16 ─────────────────────┼──── button black left  ─────── GND
   │                               │
   │  ── BOUTONS CÔTÉ DROIT ────  │
-  │  GPIO 13 ─────────────────────┼──── Bouton 3 : Flipper Droit  ──── GND
-  │  GPIO 15 ─────────────────────┼──── Bouton 4 : Droit 2        ──── GND
+  │  GPIO 25 ─────────────────────┼──── button white right ─────── GND
+  │  GPIO 13 ─────────────────────┼──── button black right ─────── GND
   │                               │
   │  ── BOUTONS FACE AVANT ────  │
-  │  GPIO 16 ─────────────────────┼──── Bouton 5 : Start          ──── GND
-  │  GPIO 17 ─────────────────────┼──── Bouton 6 : Face 2         ──── GND
-  │  GPIO 18 ─────────────────────┼──── Bouton 7 : Face 3         ──── GND
+  │  GPIO 17 ─────────────────────┼──── button front left green ── GND
+  │  GPIO 18 ─────────────────────┼──── button front left yellow ─ GND
+  │  GPIO 19 ─────────────────────┼──── button front left red ──── GND
+  │  GPIO 33 ─────────────────────┼──── button front white ─────── GND
   │                               │
-  │  ── JETON ─────────────────  │
-  │  GPIO 19 ─────────────────────┼──── Bouton 8 : Jeton/Pièce    ──── GND
-  │                               │
-  │  ── TIRETTE (ANALOGIQUE) ──  │
-  │  GPIO 32 (ADC1) ─────────────┼──── Potentiomètre linéaire ──── 3.3V
-  │  GND ─────────────────────────┼──── (autre borne)         ──── GND
-  │                               │     Curseur → GPIO 32
-  │                               │     0V = repos, 3.3V = tiré à fond
+  │  ── PLUNGER ──────────────── │
+  │  GPIO 32 ────────────────────┼──── plunger ─────────────── GND
   │                               │
   │  ── CAPTEUR TILT ──────────  │
   │                               │         ┌──────────────┐
@@ -394,7 +387,7 @@ Le MPU-6050 communique en **I2C** avec l'ESP32 (2 fils seulement). Les événeme
   └───────────────────────────────┘
 
   Boutons : pull-up interne (INPUT_PULLUP). Appui = LOW → envoi USB série.
-  Tirette : lecture analogique (analogRead). Valeur 0-4095 → normalisée 0.0-1.0.
+  Plunger : pull-up interne (INPUT_PULLUP). Appui = LOW → envoi USB série.
   Le câble USB sert à la fois d'alimentation ET de communication.
 ```
 
@@ -402,19 +395,21 @@ Le MPU-6050 communique en **I2C** avec l'ESP32 (2 fils seulement). Les événeme
 
 | GPIO | Composant | Position | Touche / Fonction | Communication |
 |------|-----------|----------|-------------------|---------------|
-| 12 | Bouton 1 — Flipper Gauche | Côté gauche | `X` | USB série → PC |
-| 14 | Bouton 2 — Gauche 2 | Côté gauche | à définir | USB série → PC |
-| 13 | Bouton 3 — Flipper Droit | Côté droit | `C` | USB série → PC |
-| 15 | Bouton 4 — Droit 2 | Côté droit | à définir | USB série → PC |
-| 16 | Bouton 5 — Start | Face avant | `D` | USB série → PC |
-| 17 | Bouton 6 — Face 2 | Face avant | à définir | USB série → PC |
-| 18 | Bouton 7 — Face 3 | Face avant | à définir | USB série → PC |
-| 19 | Bouton 8 — Jeton/Pièce | Mécanisme | `F` | USB série → PC |
-| **32** | **Tirette (plunger)** | **Côté droit** | **Analogique 0.0→1.0** | **USB série → PC** |
+| 16 | button black left | Côté gauche | `A` | USB série → PC |
+| 4 | button white left | Côté gauche | `X` | USB série → PC |
+| 17 | button front left green | Face avant | `G` | USB série → PC |
+| 18 | button front left yellow | Face avant | `B` | USB série → PC |
+| 19 | button front left red | Face avant | `H` | USB série → PC |
+| 13 | button black right | Côté droit | `E` | USB série → PC |
+| 25 | button white right | Côté droit | `C` | USB série → PC |
+| 33 | button front white | Face avant | `F` | USB série → PC |
+| **32** | **plunger** | **Côté droit** | **Appui maintenu, simule `D`** | **USB série → PC** |
 | 21 | MPU-6050 SDA | Meuble | Données accéléromètre | I2C |
 | 22 | MPU-6050 SCL | Meuble | Horloge accéléromètre | I2C |
 
-**Note ADC :** GPIO 32 fait partie du groupe **ADC1**, le seul utilisable quand le Wi-Fi est actif. Ne jamais brancher la tirette sur un pin ADC2 (GPIO 0, 2, 4, 12-15, 25-27).
+**Note plunger :** le firmware transforme le plunger en `APPUI plunger` / `RELACHE plunger`, puis le daemon envoie la touche `D` au jeu.
+
+**Note mapping boutons :** ce mapping reprend la machine physique fournie à l'école. Le firmware de référence se trouve dans `iot/firmware/esp32_button_controller/esp32_button_controller.ino`.
 
 ---
 
@@ -536,10 +531,13 @@ Le serveur publie sur ces topics quand un événement de jeu nécessite un retou
 **NE PAS UTILISER :**
 - GPIO 0 (boot mode)
 - GPIO 2 (LED interne, peut interférer)
+- GPIO 5, 12, 15 (pins sensibles au démarrage selon le câblage)
 - GPIO 6-11 (Flash SPI interne)
 - GPIO 34-39 (input-only, pas de pull-up interne)
 
-**GPIO sûrs pour ce projet :** 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23
+**GPIO retenus pour le contrôleur boutons école :** 4, 13, 16, 17, 18, 19, 25, 33.  
+**GPIO retenus pour le tilt :** 21, 22.  
+**GPIO retenu pour le plunger :** 32.
 
 ### Alimentation
 

--- a/doc/Linux_Launcher_Flipper.md
+++ b/doc/Linux_Launcher_Flipper.md
@@ -1,0 +1,127 @@
+# Lancement automatique Linux du flipper
+
+Ce document explique comment lancer le projet sur la machine Linux du flipper
+physique sans taper manuellement la commande du daemon ESP32.
+
+## Principe
+
+Le script Linux démarre :
+
+- les services Docker du projet ;
+- le daemon des boutons ESP32 en mode clavier ;
+- le navigateur sur le playfield.
+
+Le daemon détecte automatiquement le port série de l'ESP32 avec `--auto-port`.
+
+## Prérequis
+
+- Linux avec session graphique ;
+- session graphique X11 recommandée pour l'envoi des touches clavier ;
+- Docker et Docker Compose ;
+- Python 3 avec `venv` ;
+- navigateur installé : Chromium, Chrome ou Firefox ;
+- ESP32 branché en USB ;
+- droits d'accès au port série.
+
+Si le port série n'est pas accessible, ajouter l'utilisateur au groupe `dialout`
+puis redémarrer la session :
+
+```bash
+sudo usermod -aG dialout "$USER"
+```
+
+## Lancement manuel
+
+Depuis la racine du projet :
+
+```bash
+chmod +x scripts/linux/start_flipper.sh scripts/linux/stop_flipper.sh
+./scripts/linux/start_flipper.sh
+```
+
+Pour arrêter :
+
+```bash
+./scripts/linux/stop_flipper.sh
+```
+
+Les logs du daemon sont écrits ici :
+
+```text
+.flipper-run/esp32_button_daemon.log
+```
+
+## Mode kiosque
+
+Pour ouvrir le navigateur en plein écran :
+
+```bash
+FLIPPER_KIOSK=1 ./scripts/linux/start_flipper.sh
+```
+
+## Démarrage automatique avec systemd
+
+Le fichier `scripts/linux/flipper.service` sert de modèle.
+
+Exemple avec le projet installé dans `/opt/flipper` :
+
+```bash
+sudo cp scripts/linux/flipper.service /etc/systemd/user/flipper.service
+systemctl --user daemon-reload
+systemctl --user enable flipper.service
+systemctl --user start flipper.service
+```
+
+Si le projet n'est pas installé dans `/opt/flipper`, modifier `WorkingDirectory`,
+`ExecStart` et `ExecStop` dans le fichier service avant de l'activer.
+
+Pour que le service utilisateur puisse démarrer sans terminal ouvert :
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+## Démarrage automatique avec la session graphique
+
+Pour une machine avec écran et navigateur, le démarrage par fichier `.desktop`
+est souvent plus simple que `systemd`, car il démarre dans la session graphique
+de l'utilisateur.
+
+Exemple avec le projet installé dans `/opt/flipper` :
+
+```bash
+mkdir -p ~/.config/autostart
+cp scripts/linux/flipper.desktop ~/.config/autostart/flipper.desktop
+```
+
+Si le projet n'est pas installé dans `/opt/flipper`, modifier la ligne `Exec`
+dans le fichier `.desktop`.
+
+Au prochain login, le script `start_flipper.sh` sera lancé automatiquement.
+
+## Vérifications
+
+Le jeu doit être accessible sur :
+
+```text
+http://localhost:3001
+```
+
+Le daemon doit afficher les événements des boutons dans le fichier de log :
+
+```text
+APPUI button_white_left -> x
+RELACHE button_white_left -> x
+APPUI plunger -> d
+RELACHE plunger -> d
+```
+
+## Notes
+
+- Les boutons restent en USB série pour garder une latence faible.
+- MQTT reste utilisé pour les solénoïdes, le tilt et les événements non critiques.
+- Si l'ESP32 n'est pas trouvé, lancer :
+
+```bash
+python iot/scripts/esp32_button_daemon.py --list-ports
+```

--- a/doc/Linux_Launcher_Flipper.md
+++ b/doc/Linux_Launcher_Flipper.md
@@ -30,7 +30,20 @@ puis redémarrer la session :
 sudo usermod -aG dialout "$USER"
 ```
 
-## Lancement manuel
+## Installation dans `/opt/flipper`
+
+Sur la machine finale, le chemin recommandé est `/opt/flipper`.
+
+```bash
+sudo mkdir -p /opt
+cd /opt
+sudo git clone https://github.com/AkaTFL/Flipper.git flipper
+sudo chown -R "$USER:$USER" /opt/flipper
+cd /opt/flipper
+git checkout feature/163-lancement-automatique-flipper
+```
+
+## Lancement manuel par terminal
 
 Depuis la racine du projet :
 
@@ -49,6 +62,34 @@ Les logs du daemon sont écrits ici :
 
 ```text
 .flipper-run/esp32_button_daemon.log
+```
+
+## Lancement par double clic
+
+Si le projet est installé dans `/opt/flipper`, le fichier
+`scripts/linux/flipper.desktop` peut servir de raccourci.
+
+Copier le raccourci sur le bureau :
+
+```bash
+cp /opt/flipper/scripts/linux/flipper.desktop ~/Bureau/Flipper.desktop
+chmod +x ~/Bureau/Flipper.desktop
+```
+
+Si le dossier du bureau s'appelle `Desktop` :
+
+```bash
+cp /opt/flipper/scripts/linux/flipper.desktop ~/Desktop/Flipper.desktop
+chmod +x ~/Desktop/Flipper.desktop
+```
+
+Au premier lancement, Linux peut demander d'autoriser le raccourci. Choisir
+`Faire confiance et lancer` ou `Allow Launching` selon l'environnement.
+
+Le double clic lance :
+
+```text
+/opt/flipper/scripts/linux/start_flipper.sh
 ```
 
 ## Mode kiosque

--- a/doc/Technical_Stack.md
+++ b/doc/Technical_Stack.md
@@ -106,8 +106,8 @@ C'est le cœur de la partie IoT du projet.
 #### 4.1 ESP32 : Le microcontrôleur
 **L'ESP32** est le "couteau suisse" de l'IoT pour ce projet :
 - **Wi-Fi intégré** : Connexion native au broker Mosquitto sans modules externes
-- **GPIO nombreux** : 34+ pins pour connecter bumpers, boutons, LEDs, solénoïdes
-- **Puissance** : Dual-core 240 MHz, suffisant pour lire des capteurs à 1 kHz et publier via MQTT
+- **GPIO nombreux** : assez de pins pour connecter boutons, capteurs, LEDs et relais
+- **Puissance** : Dual-core 240 MHz, suffisant pour lire les entrées et piloter la communication
 - **Coût** : ~3-5€ par module (vs 40€ pour un Arduino avec shield Wi-Fi)
 
 #### 4.2 Protocole MQTT via Mosquitto
@@ -122,19 +122,22 @@ MQTT est conçu pour les **réseaux instables**. Si un message est envoyé par u
 
 ##### b) Architecture Pub/Sub (Publish/Subscribe)
 Cela permet de **découpler totalement** le matériel (ESP32) du logiciel (Backend Go) :
-- L'ESP32 **publie** l'événement sur le topic `flipper/sensor/bumper1`
+- Les ESP32 solénoïdes **écoutent** les topics `flipper/solenoid/#`
+- L'ESP32 contrôleur peut **publier** le tilt sur `flipper/tilt/#`
 - Le backend Go **souscrit** à tous les topics `flipper/sensor/#`
 - Si on ajoute un nouveau capteur, aucun changement côté backend (juste un nouveau topic)
 
 **Architecture scalable :**
 ```
-ESP32_1 → flipper/sensor/bumper1 ┐
-ESP32_2 → flipper/sensor/bumper2 ├→ Mosquitto → Backend Go
-ESP32_3 → flipper/input/flipperL ┘
+Backend Go → Mosquitto → ESP32_1 / ESP32_2 (solénoïdes)
+ESP32_3 → Mosquitto → Backend Go (tilt)
+ESP32_3 → USB série → PC Playfield (boutons)
 ```
 
 ##### c) Faible overhead
-Les messages MQTT ont un **header de seulement 2 octets** (vs 200-800 octets pour HTTP). Sur un réseau Wi-Fi local, cela garantit une latence de **5-15ms** entre appui physique et réception côté serveur.
+Les messages MQTT ont un **header de seulement 2 octets** (vs 200-800 octets pour HTTP). Sur un réseau Wi-Fi local, c'est adapté aux solénoïdes, au tilt et aux événements non critiques.
+
+Les boutons de flipper restent en **USB série**, car ils doivent être plus réactifs qu'une entrée réseau.
 
 ---
 

--- a/doc/diagrams/Sequence.md
+++ b/doc/diagrams/Sequence.md
@@ -7,15 +7,21 @@ sequenceDiagram
   participant AI as Python AI
   participant Frontend
 
-  Player->>ESP32: Physical action / collision
-  ESP32->>MQTT: Publish hit event
-  MQTT->>Backend: Relay event
+  Player->>ESP32: Bouton physique
+  ESP32->>Frontend: USB série puis touche clavier
+  Frontend->>Backend: WebSocket event
   Backend->>AI: HTTP event
   AI->>AI: Compute new objective
   AI-->>Backend: JSON (objective/position/value)
   Backend->>Backend: Update score + state
   Backend->>Frontend: WebSocket update
   Frontend->>Frontend: Update score, DMD, effects
+
+  opt Retour haptique
+    Frontend->>Backend: WebSocket collision
+    Backend->>MQTT: Publish solenoid command
+    MQTT->>ESP32: Relay command
+  end
 
   opt Second player is AI
     Backend->>AI: HTTP event (AI turn)

--- a/frontend/flipper/core/Controls.js
+++ b/frontend/flipper/core/Controls.js
@@ -9,7 +9,7 @@ export class Controls{
      * @param {string} launch
      */
 
-    constructor(left = 'a', right = 'e', launch = 'space', bossDebug = 'b') {
+    constructor(left = 'x', right = 'c', launch = 'd', bossDebug = 'b') {
         this.left = left;
         this.right = right;
         this.launch = launch;

--- a/frontend/flipper/core/Flipper.js
+++ b/frontend/flipper/core/Flipper.js
@@ -48,7 +48,7 @@ export async function initFlipper() {
     );
 
     const container = document.getElementById('three');
-    const controls = new Controls('q', 'd', 'space');
+    const controls = new Controls('x', 'c', 'd');
     physics.controls = controls;
     physics.scene = sceneManager.scene;
     const scoreDisplay = new ScoreDisplay();

--- a/frontend/flipper/ui/ScoreDisplay.js
+++ b/frontend/flipper/ui/ScoreDisplay.js
@@ -222,9 +222,11 @@ export class ScoreDisplay {
         this.controlsContainer.appendChild(title);
 
         const controls = [
-            ['Q', 'Flipper gauche'],
-            ['D', 'Flipper droit'],
-            ['Espace', 'Lancer la bille / démarrer'],
+            ['X', 'Flipper gauche'],
+            ['C', 'Flipper droit'],
+            ['D', 'Plunger / lancer la bille'],
+            ['F', 'Crédit / jeton'],
+            ['G', 'Bouton vert'],
             ['B', 'Activer / désactiver le boss'],
             ['H', 'Test attaque boss: -20 HP'],
             ['L', 'Test perte de balle']

--- a/iot/ESP32_Button_Controller.md
+++ b/iot/ESP32_Button_Controller.md
@@ -1,0 +1,145 @@
+# Contrôleur boutons ESP32
+
+Ce document décrit le test des boutons physiques pour l'issue `#148`.
+
+## Matériel
+
+- ESP32 DevKit avec module `ESP32-WROOM-32D`
+- 8 boutons
+- 1 plunger branché comme bouton
+- câble USB vers l'ordinateur
+
+Les boutons utilisent le pull-up interne de l'ESP32. Il ne faut pas brancher les
+boutons sur le `5V`.
+
+```text
+GPIO ---- bouton ---- GND
+```
+
+Bouton relâché : `HIGH`  
+Bouton appuyé : `LOW`
+
+## Mapping GPIO
+
+| Fonction | GPIO ESP32 | Nom série |
+|---|---:|---|
+| Bouton noir gauche | `16` | `button_black_left` |
+| Bouton blanc gauche | `4` | `button_white_left` |
+| Bouton vert face gauche | `17` | `button_front_left_green` |
+| Bouton jaune face gauche | `18` | `button_front_left_yellow` |
+| Bouton rouge face gauche | `19` | `button_front_left_red` |
+| Bouton noir droit | `13` | `button_black_right` |
+| Bouton blanc droit | `25` | `button_white_right` |
+| Bouton blanc face | `33` | `button_front_white` |
+| Plunger | `32` | `plunger` |
+
+Le GPIO `32` est lu comme un bouton. Le jeu utilise la durée entre `APPUI
+plunger` et `RELACHE plunger` pour régler la force de lancement de la bille.
+
+## Code ESP32
+
+Le sketch Arduino est ici :
+
+```text
+iot/firmware/esp32_button_controller/esp32_button_controller.ino
+```
+
+Réglages Arduino IDE :
+
+- carte : `ESP32 Dev Module`
+- moniteur série : `115200`
+
+Sortie attendue :
+
+```text
+Test controles Flipper ESP32 pret
+APPUI button_white_left
+RELACHE button_white_left
+APPUI plunger
+RELACHE plunger
+```
+
+## Script ordinateur
+
+Le script lit l'USB série et peut transformer les messages en touches clavier.
+Il fonctionne sur macOS, Windows et Linux avec Python.
+
+Installation macOS / Linux :
+
+```bash
+python3 -m venv /tmp/flipper-esp32-venv
+source /tmp/flipper-esp32-venv/bin/activate
+pip install -r iot/scripts/requirements.txt
+```
+
+Installation Windows PowerShell :
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r iot\scripts\requirements.txt
+```
+
+Lister les ports :
+
+```bash
+python iot/scripts/esp32_button_daemon.py --list-ports
+```
+
+Sur Windows :
+
+```powershell
+python iot\scripts\esp32_button_daemon.py --list-ports
+```
+
+Test sans envoyer les touches :
+
+```bash
+python iot/scripts/esp32_button_daemon.py --port /dev/cu.usbserial-0001
+```
+
+Sur Windows, le port ressemble plutôt à `COM3` :
+
+```powershell
+python iot\scripts\esp32_button_daemon.py --port COM3
+```
+
+Mode clavier :
+
+```bash
+python iot/scripts/esp32_button_daemon.py --port /dev/cu.usbserial-0001 --clavier
+```
+
+Windows :
+
+```powershell
+python iot\scripts\esp32_button_daemon.py --port COM3 --clavier
+```
+
+Il faut garder la fenêtre du jeu au premier plan pendant le test.
+
+Sur macOS, il peut être nécessaire d'autoriser le terminal dans les réglages
+d'accessibilité.
+
+## Mapping clavier
+
+| Nom série | Touche envoyée |
+|---|---|
+| `button_black_left` | `a` |
+| `button_white_left` | `x` |
+| `button_front_left_green` | `g` |
+| `button_front_left_yellow` | `b` |
+| `button_front_left_red` | `h` |
+| `button_black_right` | `e` |
+| `button_white_right` | `c` |
+| `button_front_white` | `f` |
+| `plunger` | `d` |
+
+Exemple pour changer une touche :
+
+```bash
+python iot/scripts/esp32_button_daemon.py \
+  --port /dev/cu.usbserial-0001 \
+  --clavier \
+  --map plunger=d
+```

--- a/iot/README.md
+++ b/iot/README.md
@@ -67,6 +67,18 @@ iot/firmware/esp32_button_controller/esp32_button_controller.ino
 La documentation de câblage, de mapping GPIO et d'utilisation sur ordinateur est
 dans `iot/ESP32_Button_Controller.md`.
 
+Le daemon peut détecter automatiquement le port de l'ESP32 :
+
+```bash
+python iot/scripts/esp32_button_daemon.py --auto-port --clavier
+```
+
+Pour le lancement automatique sur la machine Linux du flipper, voir :
+
+```text
+doc/Linux_Launcher_Flipper.md
+```
+
 ## Standardisation des topics
 
 - `topic_registry.json` : registre versionné (JSON), aligné sur `doc/Hardware_Architecture.md`.

--- a/iot/README.md
+++ b/iot/README.md
@@ -20,8 +20,20 @@ Arrêt : `docker compose down`.
 
 ## Scripts Python
 
+Sur macOS avec Python Homebrew, utilise plutôt un environnement virtuel :
+
 ```bash
+python3 -m venv /tmp/flipper-esp32-venv
+source /tmp/flipper-esp32-venv/bin/activate
 pip install -r iot/scripts/requirements.txt
+```
+
+Sur Windows PowerShell :
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r iot\scripts\requirements.txt
 ```
 
 | Script | Rôle |
@@ -32,6 +44,7 @@ pip install -r iot/scripts/requirements.txt
 | `stability_run.py` | Charge et taux de perte (semaines 4 & 8) |
 | `monitor_sys.py` | Topics `$SYS` Mosquitto (semaine 7) |
 | `publish_solenoid_sample.py` | Exemple commande solénoïde JSON compact (semaine 6) |
+| `esp32_button_daemon.py` | Lit le contrôleur boutons ESP32 en USB série et peut envoyer des touches sur macOS, Windows et Linux |
 
 Exemples :
 
@@ -40,7 +53,19 @@ python iot/scripts/publish_hello.py --host 127.0.0.1
 python iot/scripts/fake_esp32_publisher.py --cycles 3 --interval 1
 python iot/scripts/stability_run.py --duration 15 --rate 40
 python iot/scripts/monitor_sys.py --seconds 5
+python iot/scripts/esp32_button_daemon.py --list-ports
 ```
+
+## Contrôleur boutons ESP32
+
+Le firmware du contrôleur joueur se trouve ici :
+
+```text
+iot/firmware/esp32_button_controller/esp32_button_controller.ino
+```
+
+La documentation de câblage, de mapping GPIO et d'utilisation sur ordinateur est
+dans `iot/ESP32_Button_Controller.md`.
 
 ## Standardisation des topics
 

--- a/iot/firmware/esp32_button_controller/esp32_button_controller.ino
+++ b/iot/firmware/esp32_button_controller/esp32_button_controller.ino
@@ -1,0 +1,85 @@
+const int BUTTON_BLACK_LEFT = 16;
+const int BUTTON_WHITE_LEFT = 4;
+const int BUTTON_FRONT_LEFT_GREEN = 17;
+const int BUTTON_FRONT_LEFT_YELLOW = 18;
+const int BUTTON_FRONT_LEFT_RED = 19;
+const int BUTTON_BLACK_RIGHT = 13;
+const int BUTTON_WHITE_RIGHT = 25;
+const int BUTTON_FRONT_WHITE = 33;
+const int PLUNGER = 32;
+
+const int NB_BOUTONS = 9;
+const unsigned long DEBOUNCE_MS = 30;
+
+const int boutons[NB_BOUTONS] = {
+  BUTTON_BLACK_LEFT,
+  BUTTON_WHITE_LEFT,
+  BUTTON_FRONT_LEFT_GREEN,
+  BUTTON_FRONT_LEFT_YELLOW,
+  BUTTON_FRONT_LEFT_RED,
+  BUTTON_BLACK_RIGHT,
+  BUTTON_WHITE_RIGHT,
+  BUTTON_FRONT_WHITE,
+  PLUNGER
+};
+
+const char* noms[NB_BOUTONS] = {
+  "button_black_left",
+  "button_white_left",
+  "button_front_left_green",
+  "button_front_left_yellow",
+  "button_front_left_red",
+  "button_black_right",
+  "button_white_right",
+  "button_front_white",
+  "plunger"
+};
+
+int anciensEtats[NB_BOUTONS];
+unsigned long dernierChangement[NB_BOUTONS];
+
+void setup() {
+  Serial.begin(115200);
+
+  for (int i = 0; i < NB_BOUTONS; i++) {
+    pinMode(boutons[i], INPUT_PULLUP);
+    anciensEtats[i] = digitalRead(boutons[i]);
+    dernierChangement[i] = 0;
+  }
+
+  Serial.println("Test controles Flipper ESP32 pret");
+}
+
+void loop() {
+  const unsigned long maintenant = millis();
+
+  for (int i = 0; i < NB_BOUTONS; i++) {
+    int etat = digitalRead(boutons[i]);
+
+    if (etat == anciensEtats[i]) {
+      continue;
+    }
+
+    if (maintenant - dernierChangement[i] < DEBOUNCE_MS) {
+      continue;
+    }
+
+    dernierChangement[i] = maintenant;
+    delay(DEBOUNCE_MS);
+
+    int etatConfirme = digitalRead(boutons[i]);
+    if (etatConfirme != etat) {
+      continue;
+    }
+
+    if (etatConfirme == LOW) {
+      Serial.print("APPUI ");
+      Serial.println(noms[i]);
+    } else {
+      Serial.print("RELACHE ");
+      Serial.println(noms[i]);
+    }
+
+    anciensEtats[i] = etatConfirme;
+  }
+}

--- a/iot/scripts/esp32_button_daemon.py
+++ b/iot/scripts/esp32_button_daemon.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Lecture du contrôleur ESP32 en USB série.
+"""
+
+import argparse
+import sys
+import time
+
+try:
+    import serial
+    from serial.tools import list_ports
+except ImportError as exc:
+    print("pyserial est requis. Lance: pip install -r iot/scripts/requirements.txt", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+try:
+    import pyautogui
+except ImportError:
+    pyautogui = None
+
+
+TOUCHES = {
+    "button_black_left": "a",
+    "button_white_left": "x",
+    "button_front_left_green": "g",
+    "button_front_left_yellow": "b",
+    "button_front_left_red": "h",
+    "button_black_right": "e",
+    "button_white_right": "c",
+    "button_front_white": "f",
+    "plunger": "d",
+}
+
+TOUCHES_SPECIALES = {
+    "space": " ",
+    "return": "enter",
+    "enter": "enter",
+    "escape": "esc",
+    "esc": "esc",
+    "tab": "tab",
+}
+
+ACTIONS = {
+    "APPUI": "APPUI",
+    "RELACHE": "RELACHE",
+    "PRESS": "APPUI",
+    "RELEASE": "RELACHE",
+}
+
+
+def lister_ports() -> list[str]:
+    return [port.device for port in list_ports.comports()]
+
+
+def lire_ligne(ligne: str):
+    morceaux = ligne.strip().split(maxsplit=1)
+    if len(morceaux) != 2:
+        return None
+
+    action = ACTIONS.get(morceaux[0].upper())
+    nom = morceaux[1].strip()
+    if action is None or not nom:
+        return None
+
+    return action, nom
+
+
+def envoyer_touche(action: str, touche: str) -> None:
+    if pyautogui is None:
+        raise RuntimeError("pyautogui est requis pour le mode --clavier")
+
+    touche = TOUCHES_SPECIALES.get(touche, touche)
+    if action == "APPUI":
+        pyautogui.keyDown(touche)
+    elif action == "RELACHE":
+        pyautogui.keyUp(touche)
+
+
+def ouvrir_serie(port: str, baud: int, timeout: float):
+    return serial.Serial(port=port, baudrate=baud, timeout=timeout)
+
+
+def lancer(args: argparse.Namespace) -> int:
+    if args.list_ports:
+        ports = lister_ports()
+        if not ports:
+            print("Aucun port série trouvé")
+            return 0
+        for port in ports:
+            print(port)
+        return 0
+
+    if not args.port:
+        print("Port manquant. Utilise --list-ports pour trouver l'ESP32.", file=sys.stderr)
+        return 2
+
+    touches = dict(TOUCHES)
+    for valeur in args.map:
+        if "=" not in valeur:
+            print(f"Mapping invalide: {valeur!r}. Format attendu: bouton=touche", file=sys.stderr)
+            return 2
+        bouton, touche = valeur.split("=", 1)
+        touches[bouton.strip()] = touche.strip().lower()
+
+    print(f"Ouverture de {args.port} à {args.baud} bauds")
+    if args.clavier:
+        if pyautogui is None:
+            print("pyautogui manquant. Lance: pip install -r iot/scripts/requirements.txt", file=sys.stderr)
+            return 2
+        print("Mode clavier activé. Garde la fenêtre du jeu au premier plan.")
+    else:
+        print("Mode affichage uniquement. Ajoute --clavier pour envoyer les touches.")
+
+    with ouvrir_serie(args.port, args.baud, args.timeout) as appareil:
+        time.sleep(args.ready_delay)
+        while True:
+            ligne_brute = appareil.readline()
+            if not ligne_brute:
+                continue
+
+            ligne = ligne_brute.decode("utf-8", errors="replace").strip()
+            if not ligne:
+                continue
+
+            evenement = lire_ligne(ligne)
+            if evenement is None:
+                print(ligne)
+                continue
+
+            action, nom = evenement
+            touche = touches.get(nom)
+            if touche is None:
+                print(f"{action} {nom} -> non associé")
+                continue
+
+            print(f"{action} {nom} -> {touche}")
+            if args.clavier:
+                envoyer_touche(action, touche)
+
+
+def construire_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lecture USB série des boutons ESP32 du flipper")
+    parser.add_argument("--port", help="Port série, exemple: /dev/cu.usbserial-0001 ou COM3")
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--timeout", type=float, default=0.1)
+    parser.add_argument("--ready-delay", type=float, default=1.5)
+    parser.add_argument("--list-ports", action="store_true", help="Liste les ports série disponibles")
+    parser.add_argument("--clavier", "--keyboard", action="store_true", help="Envoie les touches au système")
+    parser.add_argument(
+        "--map",
+        action="append",
+        default=[],
+        metavar="BUTTON=KEY",
+        help="Change une touche, exemple: --map start=space",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = construire_parser()
+    args = parser.parse_args()
+    try:
+        return lancer(args)
+    except KeyboardInterrupt:
+        print("\nArrêt")
+        return 0
+    except serial.SerialException as exc:
+        print(f"Erreur série: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/iot/scripts/esp32_button_daemon.py
+++ b/iot/scripts/esp32_button_daemon.py
@@ -53,6 +53,36 @@ def lister_ports() -> list[str]:
     return [port.device for port in list_ports.comports()]
 
 
+def trouver_port_esp32() -> str | None:
+    mots_cles = (
+        "usbserial",
+        "usbmodem",
+        "ttyusb",
+        "ttyacm",
+        "cp210",
+        "ch340",
+        "wch",
+        "silicon labs",
+        "espressif",
+        "esp32",
+    )
+
+    ports = list(list_ports.comports())
+    for port in ports:
+        texte = " ".join(
+            str(valeur).lower()
+            for valeur in (port.device, port.description, port.manufacturer, port.hwid)
+            if valeur
+        )
+        if any(mot in texte for mot in mots_cles):
+            return port.device
+
+    if len(ports) == 1:
+        return ports[0].device
+
+    return None
+
+
 def lire_ligne(ligne: str):
     morceaux = ligne.strip().split(maxsplit=1)
     if len(morceaux) != 2:
@@ -91,8 +121,12 @@ def lancer(args: argparse.Namespace) -> int:
             print(port)
         return 0
 
-    if not args.port:
-        print("Port manquant. Utilise --list-ports pour trouver l'ESP32.", file=sys.stderr)
+    port = args.port
+    if args.auto_port or not port:
+        port = trouver_port_esp32()
+
+    if not port:
+        print("Port ESP32 introuvable. Utilise --list-ports pour vérifier.", file=sys.stderr)
         return 2
 
     touches = dict(TOUCHES)
@@ -103,7 +137,7 @@ def lancer(args: argparse.Namespace) -> int:
         bouton, touche = valeur.split("=", 1)
         touches[bouton.strip()] = touche.strip().lower()
 
-    print(f"Ouverture de {args.port} à {args.baud} bauds")
+    print(f"Ouverture de {port} à {args.baud} bauds")
     if args.clavier:
         if pyautogui is None:
             print("pyautogui manquant. Lance: pip install -r iot/scripts/requirements.txt", file=sys.stderr)
@@ -112,7 +146,7 @@ def lancer(args: argparse.Namespace) -> int:
     else:
         print("Mode affichage uniquement. Ajoute --clavier pour envoyer les touches.")
 
-    with ouvrir_serie(args.port, args.baud, args.timeout) as appareil:
+    with ouvrir_serie(port, args.baud, args.timeout) as appareil:
         time.sleep(args.ready_delay)
         while True:
             ligne_brute = appareil.readline()
@@ -146,6 +180,7 @@ def construire_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", type=float, default=0.1)
     parser.add_argument("--ready-delay", type=float, default=1.5)
     parser.add_argument("--list-ports", action="store_true", help="Liste les ports série disponibles")
+    parser.add_argument("--auto-port", action="store_true", help="Détecte automatiquement le port ESP32")
     parser.add_argument("--clavier", "--keyboard", action="store_true", help="Envoie les touches au système")
     parser.add_argument(
         "--map",

--- a/iot/scripts/requirements.txt
+++ b/iot/scripts/requirements.txt
@@ -1,1 +1,3 @@
 paho-mqtt>=1.6.1,<2.0.0
+pyserial>=3.5,<4.0
+pyautogui>=0.9.54,<1.0.0

--- a/scripts/linux/flipper.desktop
+++ b/scripts/linux/flipper.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Flipper
+Comment=Lance automatiquement le flipper physique
+Exec=/opt/flipper/scripts/linux/start_flipper.sh
+Terminal=false
+X-GNOME-Autostart-enabled=true

--- a/scripts/linux/flipper.service
+++ b/scripts/linux/flipper.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Flipper - lancement automatique
+After=network-online.target docker.service graphical-session.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/flipper
+ExecStart=/opt/flipper/scripts/linux/start_flipper.sh
+ExecStop=/opt/flipper/scripts/linux/stop_flipper.sh
+Environment=FLIPPER_KIOSK=1
+
+[Install]
+WantedBy=default.target

--- a/scripts/linux/start_flipper.sh
+++ b/scripts/linux/start_flipper.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="$ROOT_DIR/.flipper-run"
+VENV_DIR="$ROOT_DIR/.venv-flipper"
+DAEMON_PID_FILE="$LOG_DIR/esp32_button_daemon.pid"
+FRONTEND_URL="${FLIPPER_FRONTEND_URL:-http://localhost:3001}"
+
+mkdir -p "$LOG_DIR"
+
+cd "$ROOT_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker est introuvable. Installe Docker avant de lancer le flipper."
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE=(docker-compose)
+else
+  echo "Docker Compose est introuvable."
+  exit 1
+fi
+
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+"$VENV_DIR/bin/python" -m pip install -q -r "$ROOT_DIR/iot/scripts/requirements.txt"
+
+echo "Démarrage des services Docker..."
+"${DOCKER_COMPOSE[@]}" up -d --build
+
+if [ -f "$DAEMON_PID_FILE" ] && kill -0 "$(cat "$DAEMON_PID_FILE")" 2>/dev/null; then
+  echo "Le daemon boutons ESP32 est déjà lancé."
+else
+  echo "Démarrage du daemon boutons ESP32..."
+  nohup "$VENV_DIR/bin/python" "$ROOT_DIR/iot/scripts/esp32_button_daemon.py" \
+    --auto-port \
+    --clavier \
+    > "$LOG_DIR/esp32_button_daemon.log" 2>&1 &
+  echo "$!" > "$DAEMON_PID_FILE"
+fi
+
+echo "Ouverture du jeu : $FRONTEND_URL"
+if command -v chromium-browser >/dev/null 2>&1; then
+  if [ "${FLIPPER_KIOSK:-0}" = "1" ]; then
+    nohup chromium-browser --kiosk "$FRONTEND_URL" >/dev/null 2>&1 &
+  else
+    nohup chromium-browser "$FRONTEND_URL" >/dev/null 2>&1 &
+  fi
+elif command -v chromium >/dev/null 2>&1; then
+  if [ "${FLIPPER_KIOSK:-0}" = "1" ]; then
+    nohup chromium --kiosk "$FRONTEND_URL" >/dev/null 2>&1 &
+  else
+    nohup chromium "$FRONTEND_URL" >/dev/null 2>&1 &
+  fi
+elif command -v google-chrome >/dev/null 2>&1; then
+  if [ "${FLIPPER_KIOSK:-0}" = "1" ]; then
+    nohup google-chrome --kiosk "$FRONTEND_URL" >/dev/null 2>&1 &
+  else
+    nohup google-chrome "$FRONTEND_URL" >/dev/null 2>&1 &
+  fi
+elif command -v firefox >/dev/null 2>&1; then
+  if [ "${FLIPPER_KIOSK:-0}" = "1" ]; then
+    nohup firefox --kiosk "$FRONTEND_URL" >/dev/null 2>&1 &
+  else
+    nohup firefox "$FRONTEND_URL" >/dev/null 2>&1 &
+  fi
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$FRONTEND_URL" >/dev/null 2>&1 &
+else
+  echo "Navigateur introuvable. Ouvre manuellement : $FRONTEND_URL"
+fi
+
+echo "Flipper lancé."
+echo "Logs du daemon : $LOG_DIR/esp32_button_daemon.log"

--- a/scripts/linux/stop_flipper.sh
+++ b/scripts/linux/stop_flipper.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="$ROOT_DIR/.flipper-run"
+DAEMON_PID_FILE="$LOG_DIR/esp32_button_daemon.pid"
+
+cd "$ROOT_DIR"
+
+if [ -f "$DAEMON_PID_FILE" ]; then
+  PID="$(cat "$DAEMON_PID_FILE")"
+  if kill -0 "$PID" 2>/dev/null; then
+    echo "Arrêt du daemon boutons ESP32..."
+    kill "$PID"
+  fi
+  rm -f "$DAEMON_PID_FILE"
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  docker compose down
+elif command -v docker-compose >/dev/null 2>&1; then
+  docker-compose down
+else
+  echo "Docker Compose est introuvable, arrêt des conteneurs ignoré."
+fi
+
+echo "Flipper arrêté."

--- a/tests/frontend/controls.test.js
+++ b/tests/frontend/controls.test.js
@@ -30,7 +30,7 @@ test('Controls triggers start_game callback on first launch impulse', () => {
   let now = 1000;
   Date.now = () => now;
 
-  const controls = new Controls('q', 'd', 'space');
+  const controls = new Controls('x', 'c', 'd');
   let startGameCalls = 0;
   let impulses = 0;
 
@@ -45,9 +45,9 @@ test('Controls triggers start_game callback on first launch impulse', () => {
     }
   });
 
-  windowStub.listeners.get('keydown')({ key: ' ', preventDefault() {}, repeat: false });
+  windowStub.listeners.get('keydown')({ key: 'd', preventDefault() {}, repeat: false });
   now = 1200;
-  windowStub.listeners.get('keyup')({ key: ' ', preventDefault() {} });
+  windowStub.listeners.get('keyup')({ key: 'd', preventDefault() {} });
 
   assert.equal(startGameCalls, 1);
   assert.equal(impulses, 1);
@@ -61,7 +61,7 @@ test('Controls triggers boss_fight_started callback on debug key press', () => {
   const windowStub = createWindowStub();
   globalThis.window = windowStub;
 
-  const controls = new Controls('q', 'd', 'space', 'b');
+  const controls = new Controls('x', 'c', 'd', 'b');
   let bossFightCalls = 0;
 
   controls.setBossFightStartCallback(() => {
@@ -80,7 +80,7 @@ test('Controls triggers player damage and ball lost callbacks on debug keys', ()
   const windowStub = createWindowStub();
   globalThis.window = windowStub;
 
-  const controls = new Controls('q', 'd', 'space', 'b');
+  const controls = new Controls('x', 'c', 'd', 'b');
   let damageCalls = 0;
   let ballLostCalls = 0;
 


### PR DESCRIPTION
## Résumé

Cette PR remplace #164 et regroupe deux parties liées au flipper physique :

- l’intégration du contrôleur boutons ESP32 ;
- la préparation du lancement automatique du jeu sur la machine Linux du flipper.

## Contrôleur boutons ESP32

- Ajout du firmware Arduino du contrôleur boutons ESP32 avec le mapping physique fourni pour la machine de l’école.
- Lecture des boutons physiques et du plunger via USB série.
- Ajout du daemon Python USB série vers clavier.
- Conversion des boutons vers les touches du jeu : `X`, `C`, `D`, `F`, `G`.
- Support macOS, Windows et Linux pour le daemon.
- Ajout de la détection automatique du port ESP32 avec `--auto-port`.
- Mise à jour du frontend pour afficher les contrôles correspondant au flipper physique.
- Mise à jour des tests frontend liés aux contrôles.

## Lancement automatique Linux

- Ajout de `scripts/linux/start_flipper.sh` pour démarrer Docker Compose, le daemon ESP32 et le navigateur.
- Ajout de `scripts/linux/stop_flipper.sh` pour arrêter le daemon et les services Docker.
- Ajout d’un raccourci `.desktop` pour lancement par double clic ou autostart de session graphique.
- Ajout d’un modèle `systemd` pour une installation plus automatisée.
- Documentation de l’installation recommandée dans `/opt/flipper`.
- Documentation du lancement manuel par terminal, du lancement par double clic, du mode kiosque et de l’autostart.

## Documentation

- Mise à jour de la documentation hardware et IoT.
- Clarification du rôle de l’USB série pour les boutons physiques.
- Clarification du rôle de MQTT pour les solénoïdes, le tilt et les événements non critiques.
- Ajout de `doc/Linux_Launcher_Flipper.md`.

## Tests

- `python3 -m py_compile iot/scripts/esp32_button_daemon.py`
- `node --test tests/frontend/controls.test.js`
- `bash -n scripts/linux/start_flipper.sh`
- `bash -n scripts/linux/stop_flipper.sh`

## Note

Le lancement complet devra encore être validé sur la machine Linux réelle du flipper avec l’ESP32 branché. Sur Mac, la détection automatique du port et les boutons physiques ont déjà été testés avec succès.

Closes #148
Closes #163
