### PR TITLE
DMD : adapter l’affichage à 95 % de l’écran

### DIFF
--- a/frontend/dmd/DmdDisplay.js
+++ b/frontend/dmd/DmdDisplay.js
@@ -204,9 +204,9 @@ export class DmdDisplay {
 
         this.resizeFrame = globalThis.requestAnimationFrame(() => {
             const lines = [
-                { element: this.titleEl, widthRatio: 0.9 },
-                { element: this.mainEl, widthRatio: 0.82 },
-                { element: this.subEl, widthRatio: 0.9 }
+                { element: this.titleEl, widthRatio: 0.95 },
+                { element: this.mainEl, widthRatio: 0.92 },
+                { element: this.subEl, widthRatio: 0.95 }
             ];
 
             for (const line of lines) {

--- a/frontend/dmd/index.html
+++ b/frontend/dmd/index.html
@@ -43,16 +43,16 @@
         --dmd-color: rgb(4, 190, 200);
         --dmd-glow: rgba(4, 190, 200, 0.85);
         position: fixed;
-        inset: 0;
+        inset: 2.5vh 2.5vw;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
         gap: 4vh;
-        width: 100vw;
-        height: 100vh;
+        width: 95vw;
+        height: 95vh;
         overflow: hidden;
-        padding: 4vh 4vw;
+        padding: 1vh 1vw;
         color: var(--dmd-color);
         font-family: "Press Start 2P", monospace;
         font-weight: 400;
@@ -78,16 +78,16 @@
       }
 
       .dmd-title {
-        font-size: 8vh;
+        font-size: 15vh;
         color: rgb(255, 220, 90);
       }
 
       .dmd-main {
-        font-size: 23vh;
+        font-size: 50vh;
       }
 
       .dmd-sub {
-        font-size: 7vh;
+        font-size: 12vh;
       }
 
       .dmd-points .dmd-main,
@@ -154,7 +154,7 @@
     <div id="score"></div>
 
     <script type="module">
-      import { DmdDisplay } from './DmdDisplay.js?v=4';
+      import { DmdDisplay } from './DmdDisplay.js?v=5';
 
       new DmdDisplay();
     </script>

--- a/tests/frontend/dmd-display.test.js
+++ b/tests/frontend/dmd-display.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { DmdDisplay } from '../../frontend/dmd/DmdDisplay.js';
+
+const dmdHtml = readFileSync(new URL('../../frontend/dmd/index.html', import.meta.url), 'utf8');
 
 function createFakeElement(tagName) {
   return {
@@ -122,4 +125,16 @@ test('DmdDisplay conserve la couleur du multiplicateur sur le score', () => {
 
   assert.equal(display.rootEl.className, 'dmd-screen dmd-score dmd-multiplier-3');
   assert.equal(display.mainEl.textContent, '4 500');
+});
+
+test('le DMD utilise 95 % de la surface avec une marge centrée', () => {
+  assert.match(dmdHtml, /inset:\s*2\.5vh 2\.5vw/);
+  assert.match(dmdHtml, /width:\s*95vw/);
+  assert.match(dmdHtml, /height:\s*95vh/);
+});
+
+test('les trois lignes du DMD utilisent les tailles prévues pour le meuble', () => {
+  assert.match(dmdHtml, /\.dmd-title\s*{[^}]*font-size:\s*15vh/s);
+  assert.match(dmdHtml, /\.dmd-main\s*{[^}]*font-size:\s*50vh/s);
+  assert.match(dmdHtml, /\.dmd-sub\s*{[^}]*font-size:\s*12vh/s);
 });


### PR DESCRIPTION
## Description

Cette PR adapte le DMD à la surface réelle de l’écran physique 1920 × 1080.

## Modifications

- zone DMD centrée de `95vw × 95vh` ;
- marge de sécurité de `2.5vh / 2.5vw` ;
- agrandissement du titre, du score principal et de la ligne secondaire ;
- adaptation automatique conservée pour les textes longs ;
- largeur maximale ajustée pour les trois lignes ;
- version du script DMD actualisée pour éviter le cache navigateur ;
- tests ajoutés pour la surface et les tailles du meuble.

## Validation

- `node --test tests/frontend/dmd-display.test.js` : 8/8 OK ;
- `npm run lint` : OK ;
- `git diff --check` : OK ;
- configuration Docker Compose : OK ;
- image Docker `flipper-dmd-issue-181` : build OK ;
- démarrage du container et vérification HTTP des fichiers DMD : OK ;
- validation finale à effectuer sur l’écran DMD physique.

Closes #181
