### PR TITLE
Backend : corriger la connexion locale et adapter les commandes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Participants :
 
 
 Organisation sur la base d'un Gitflow
+
+## Contrôles
+
+Le mapping clavier et ESP32 utilisé par le projet est documenté dans
+[`doc/Controles_flipper.md`](doc/Controles_flipper.md).

--- a/deploy/nginx.dev.conf
+++ b/deploy/nginx.dev.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /ws {
+        proxy_pass http://backend:8080/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 1h;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/doc/Controles_flipper.md
+++ b/doc/Controles_flipper.md
@@ -1,0 +1,52 @@
+# Contrôles clavier et boutons physiques
+
+Ce document est la référence commune pour les contrôles du Playfield, le clavier et l'ESP32.
+
+## Contrôles de jeu
+
+| Contrôle physique ESP32 | Touche | Action |
+|---|---|---|
+| `black-left` | `Q` | Active le flipper gauche |
+| `white-left` | `W` | Active également le flipper gauche |
+| `black-right` | `D` | Active le flipper droit |
+| `white-right` | `C` | Active également le flipper droit |
+| `plunger` | `Espace` | Charge puis lance la bille |
+
+Les deux boutons d'un même côté commandent le même flipper. Ils peuvent être utilisés séparément ou simultanément.
+
+## Contrôles de test
+
+| Contrôle physique ESP32 | Touche | Action de test |
+|---|---|---|
+| `front-left-yellow` | `B` | Active ou désactive le boss fight |
+| `front-left-red` | `H` | Simule une perte de 20 HP |
+| `front-left-green` | `L` | Simule une perte de balle |
+| `front-white` | `F` | Réservé pour une action future |
+
+Les touches `B`, `H` et `L` sont des commandes de debug. Elles permettent de vérifier le gameplay sans attendre l'événement réel.
+
+## Chaîne de communication
+
+```text
+Bouton physique
+→ ESP32 (nom du bouton)
+→ bridge série
+→ endpoint /events
+→ CabinetButtons.js (conversion en touche)
+→ Controls.js (action du jeu)
+```
+
+Le firmware ESP32 envoie le nom du bouton, pas la touche. Le mapping des touches reste donc dans `frontend/flipper/core/CabinetButtons.js`.
+
+## Fichiers à maintenir ensemble
+
+Lors d'un changement de contrôle, vérifier :
+
+- `frontend/flipper/core/CabinetButtons.js` : bouton physique vers touche ;
+- `frontend/flipper/core/Controls.js` : interprétation des touches ;
+- `frontend/flipper/core/Flipper.js` : configuration utilisée par la partie ;
+- `frontend/flipper/index.html` : aide affichée avant le lancement ;
+- `tests/frontend/cabinet-buttons.test.js` et `tests/frontend/controls.test.js` ;
+- ce document.
+
+Le firmware ne doit être modifié que si le nom du bouton ou son GPIO change.

--- a/doc/Systeme_boss_fight_player_state.md
+++ b/doc/Systeme_boss_fight_player_state.md
@@ -164,6 +164,16 @@ Pendant le developpement, le frontend expose des touches simples pour tester la 
 | `H` | simule une attaque du boss et retire `20 HP` au joueur |
 | `L` | simule une perte de balle |
 
+Sur le meuble physique, ces touches sont envoyees par les boutons suivants :
+
+| Bouton ESP32 | Touche | Simulation |
+|---|---|---|
+| `front-left-yellow` | `B` | boss fight |
+| `front-left-red` | `H` | perte de HP |
+| `front-left-green` | `L` | perte de balle |
+
+Le mapping complet est centralise dans [`Controles_flipper.md`](Controles_flipper.md).
+
 Ces touches sont temporaires et servent uniquement au debug gameplay.
 
 ## Equilibrage initial

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - "${FRONTEND_PORT:-3001}:80"
     volumes:
       - ./frontend/flipper:/usr/share/nginx/html
+      - ./deploy/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       backend:
         condition: service_healthy
@@ -60,6 +61,7 @@ services:
       - "${BACKGLASS_PORT:-3002}:80"
     volumes:
       - ./frontend/backglass:/usr/share/nginx/html
+      - ./deploy/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       backend:
         condition: service_healthy
@@ -74,6 +76,7 @@ services:
       - "${DMD_PORT:-3003}:80"
     volumes:
       - ./frontend/dmd:/usr/share/nginx/html
+      - ./deploy/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/flipper/core/CabinetButtons.js
+++ b/frontend/flipper/core/CabinetButtons.js
@@ -1,13 +1,13 @@
-const BUTTON_KEYS = {
-    'black-left': 'a',
-    'white-left': 'x',
-    'front-left-green': 'g',
+export const CABINET_BUTTON_KEYS = {
+    'black-left': 'q',
+    'white-left': 'w',
+    'front-left-green': 'l',
     'front-left-yellow': 'b',
     'front-left-red': 'h',
-    'black-right': 'e',
+    'black-right': 'd',
     'white-right': 'c',
     'front-white': 'f',
-    plunger: 'd'
+    plunger: ' '
 };
 
 export class CabinetButtons {
@@ -47,7 +47,7 @@ export class CabinetButtons {
         for (const [name, active] of Object.entries(buttons)) {
             if (this.previousButtons[name] === active) continue;
 
-            const key = BUTTON_KEYS[name];
+            const key = CABINET_BUTTON_KEYS[name];
             if (key) {
                 const KeyboardEventClass = this.windowRef?.KeyboardEvent ?? globalThis.KeyboardEvent;
                 this.windowRef.dispatchEvent(new KeyboardEventClass(active ? 'keydown' : 'keyup', {

--- a/frontend/flipper/core/Controls.js
+++ b/frontend/flipper/core/Controls.js
@@ -3,18 +3,22 @@ import { AudioManager } from '../physics/Audio.js';
 
 export class Controls{
     /**
-     * @param {string} left
-     * @param {string} right
+     * @param {string|string[]} left
+     * @param {string|string[]} right
      * @param {string} launch
      */
 
-    constructor(left = 'a', right = 'e', launch = 'space', bossDebug = 'b') {
-        this.left = left;
-        this.right = right;
-        this.launch = launch;
-        this.bossDebug = bossDebug;
+    constructor(left = 'q', right = 'd', launch = 'space', bossDebug = 'b') {
+        this.leftKeys = this.normalizeKeys(left);
+        this.rightKeys = this.normalizeKeys(right);
+        this.left = [...this.leftKeys][0];
+        this.right = [...this.rightKeys][0];
+        this.launch = this.normalizeKey(launch);
+        this.bossDebug = this.normalizeKey(bossDebug);
         this.playerDamageDebug = 'h';
         this.ballLostDebug = 'l';
+        this.pressedLeftKeys = new Set();
+        this.pressedRightKeys = new Set();
 
         this.input = { left: false, right: false, launch: false, launchPower: 0 };
 
@@ -30,6 +34,15 @@ export class Controls{
         this.audioManager = AudioManager.getShared();
 
         this.initControls();
+    }
+
+    normalizeKey(key) {
+        return key === ' ' ? 'space' : String(key ?? '').toLowerCase();
+    }
+
+    normalizeKeys(keys) {
+        const values = Array.isArray(keys) ? keys : [keys];
+        return new Set(values.map((key) => this.normalizeKey(key)).filter(Boolean));
     }
 
     getInputKey(event) {
@@ -48,12 +61,14 @@ export class Controls{
             this.audioManager.unlock();
             const key = this.getInputKey(e);
 
-            if (key === this.left) {
+            if (this.leftKeys.has(key)) {
+                this.pressedLeftKeys.add(key);
                 this.input.left = true;
                 console.log('Left flipper pressed');
                 return;
                 }
-            if (key === this.right) {
+            if (this.rightKeys.has(key)) {
+                this.pressedRightKeys.add(key);
                 this.input.right = true;
                 console.log('Right flipper pressed');
                 return;
@@ -93,13 +108,15 @@ export class Controls{
         window.addEventListener('keyup', (e) => {
             const key = this.getInputKey(e);
 
-            if (key === this.left) {
-                this.input.left = false;
+            if (this.leftKeys.has(key)) {
+                this.pressedLeftKeys.delete(key);
+                this.input.left = this.pressedLeftKeys.size > 0;
                 console.log('Left flipper released');
                 return;
             }
-            if (key === this.right) {
-                this.input.right = false;
+            if (this.rightKeys.has(key)) {
+                this.pressedRightKeys.delete(key);
+                this.input.right = this.pressedRightKeys.size > 0;
                 console.log('Right flipper released');
                 return;
             }

--- a/frontend/flipper/core/Flipper.js
+++ b/frontend/flipper/core/Flipper.js
@@ -49,7 +49,7 @@ export async function initFlipper() {
     );
 
     const container = document.getElementById('three');
-    const controls = new Controls('x', 'c', 'd');
+    const controls = new Controls(['q', 'w'], ['d', 'c'], 'space', 'b');
     const cabinetButtons = new CabinetButtons();
     cabinetButtons.connect();
     physics.controls = controls;

--- a/frontend/flipper/index.html
+++ b/frontend/flipper/index.html
@@ -24,15 +24,16 @@
         position: absolute;
         inset: 0;
         display: flex;
-        align-items: flex-end;
+        flex-direction: column;
+        align-items: center;
         justify-content: center;
+        gap: 18px;
         pointer-events: none;
         z-index: 10;
       }
 
       #play-button {
         pointer-events: auto;
-        margin-bottom: 18px;
         width: 54px;
         height: 54px;
         border: 0;
@@ -54,6 +55,27 @@
       #play-button:active {
         transform: scale(0.98);
       }
+
+      #controls-help {
+        padding: 18px 24px;
+        border: 1px solid rgba(255, 255, 255, 0.28);
+        border-radius: 14px;
+        background: rgba(0, 0, 0, 0.78);
+        color: #fff;
+        font: 600 16px/1.6 system-ui, sans-serif;
+        text-align: center;
+        box-shadow: 0 12px 38px rgba(0, 0, 0, 0.45);
+      }
+
+      #controls-help strong {
+        color: #75f0ff;
+      }
+
+      #controls-help .debug-controls {
+        margin-top: 8px;
+        color: rgba(255, 255, 255, 0.7);
+        font-size: 13px;
+      }
     </style>
     <script type="importmap">
       {
@@ -74,6 +96,12 @@
   </head>
   <body id="three">
     <div id="play-overlay" aria-hidden="false">
+      <div id="controls-help">
+        <div><strong>FLIPPER GAUCHE</strong> Q / W</div>
+        <div><strong>FLIPPER DROIT</strong> D / C</div>
+        <div><strong>LANCER LA BILLE</strong> ESPACE</div>
+        <div class="debug-controls">TESTS : BOSS B · PERTE HP H · PERTE DE BALLE L</div>
+      </div>
       <button id="play-button" type="button" aria-label="Lancer le flipper">▶</button>
     </div>
     <script type="module">

--- a/iot/README.md
+++ b/iot/README.md
@@ -2,6 +2,9 @@
 
 Ce dossier regroupe ce qui peut être fait **sans matériel physique** : broker, conventions de topics, tests et monitoring. La limite roadmap est la **semaine 9** (mapping GPIO) — voir l’annexe en fin de `doc/Roadmap.md`.
 
+Le mapping commun entre les boutons physiques et le clavier est documenté dans
+[`doc/Controles_flipper.md`](../doc/Controles_flipper.md).
+
 ## Prérequis
 
 - [Docker](https://docs.docker.com/get-docker/) **ou** Mosquitto installé localement (Windows : `winget install EclipseFoundation.Mosquitto`).

--- a/tests/frontend/cabinet-buttons.test.js
+++ b/tests/frontend/cabinet-buttons.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { CabinetButtons } from '../../frontend/flipper/core/CabinetButtons.js';
+import { CABINET_BUTTON_KEYS, CabinetButtons } from '../../frontend/flipper/core/CabinetButtons.js';
 
 class FakeKeyboardEvent {
   constructor(type, options) {
@@ -23,10 +23,24 @@ test('CabinetButtons transforme les changements ESP32 en touches du jeu', () => 
   buttons.handleState({ buttons: { 'white-left': false, plunger: true } });
 
   assert.deepEqual(events.map(({ type, key }) => ({ type, key })), [
-    { type: 'keydown', key: 'x' },
-    { type: 'keydown', key: 'd' },
-    { type: 'keyup', key: 'x' }
+    { type: 'keydown', key: 'w' },
+    { type: 'keydown', key: ' ' },
+    { type: 'keyup', key: 'w' }
   ]);
+});
+
+test('le mapping physique correspond aux touches documentées', () => {
+  assert.deepEqual(CABINET_BUTTON_KEYS, {
+    'black-left': 'q',
+    'white-left': 'w',
+    'front-left-green': 'l',
+    'front-left-yellow': 'b',
+    'front-left-red': 'h',
+    'black-right': 'd',
+    'white-right': 'c',
+    'front-white': 'f',
+    plunger: ' '
+  });
 });
 
 test('CabinetButtons ignore les états sans boutons', () => {

--- a/tests/frontend/cabinet-deployment.test.js
+++ b/tests/frontend/cabinet-deployment.test.js
@@ -30,6 +30,18 @@ test('nginx relaie les WebSockets et les événements des boutons', () => {
   assert.match(nginx, /proxy_buffering off/);
 });
 
+test('les trois frontends locaux utilisent le proxy WebSocket de développement', () => {
+  const compose = read('docker-compose.yml');
+  const nginx = read('deploy/nginx.dev.conf');
+  const proxyMounts = compose.match(/\.\/deploy\/nginx\.dev\.conf:\/etc\/nginx\/conf\.d\/default\.conf:ro/g) ?? [];
+
+  assert.equal(proxyMounts.length, 3);
+  assert.match(nginx, /location \/ws/);
+  assert.match(nginx, /proxy_pass http:\/\/backend:8080\/ws/);
+  assert.match(nginx, /proxy_set_header Upgrade/);
+  assert.match(nginx, /proxy_set_header Connection "upgrade"/);
+});
+
 test('le firmware final existe et reste facultatif pour le chargement', () => {
   const manifest = read('fliphetic.toml');
   const firmwareUrl = new URL('../../firmware/build/firmware.bin', import.meta.url);

--- a/tests/frontend/controls.test.js
+++ b/tests/frontend/controls.test.js
@@ -6,6 +6,7 @@ if (typeof globalThis.Audio !== 'function') {
   globalThis.Audio = class {
     constructor() { this.currentTime = 0; this.preload = 'auto'; this.volume = 1; }
     play() { return Promise.resolve(); }
+    pause() {}
   };
 }
 
@@ -96,6 +97,36 @@ test('Controls triggers player damage and ball lost callbacks on debug keys', ()
 
   assert.equal(damageCalls, 1);
   assert.equal(ballLostCalls, 1);
+
+  globalThis.window = previousWindow;
+});
+
+test('Controls accepts two keys for each flipper and preserves simultaneous presses', () => {
+  const previousWindow = globalThis.window;
+  const windowStub = createWindowStub();
+  globalThis.window = windowStub;
+
+  const controls = new Controls(['q', 'w'], ['d', 'c'], 'space', 'b');
+  const keydown = windowStub.listeners.get('keydown');
+  const keyup = windowStub.listeners.get('keyup');
+
+  keydown({ key: 'q', preventDefault() {}, repeat: false });
+  keydown({ key: 'w', preventDefault() {}, repeat: false });
+  assert.equal(controls.input.left, true);
+
+  keyup({ key: 'q', preventDefault() {} });
+  assert.equal(controls.input.left, true);
+  keyup({ key: 'w', preventDefault() {} });
+  assert.equal(controls.input.left, false);
+
+  keydown({ key: 'd', preventDefault() {}, repeat: false });
+  keydown({ key: 'c', preventDefault() {}, repeat: false });
+  assert.equal(controls.input.right, true);
+
+  keyup({ key: 'd', preventDefault() {} });
+  assert.equal(controls.input.right, true);
+  keyup({ key: 'c', preventDefault() {} });
+  assert.equal(controls.input.right, false);
 
   globalThis.window = previousWindow;
 });

--- a/tests/frontend/game-physics.test.js
+++ b/tests/frontend/game-physics.test.js
@@ -15,6 +15,17 @@ function withConfigPatch(key, value, callback) {
   }
 }
 
+function withPositioningPatch(key, value, callback) {
+  const previousValue = Config.global.positioning[key];
+  Config.global.positioning[key] = value;
+
+  try {
+    return callback();
+  } finally {
+    Config.global.positioning[key] = previousValue;
+  }
+}
+
 test('GamePhysics initializes object and collider registries', () => {
   const physics = new GamePhysics(Config);
 
@@ -62,13 +73,41 @@ test('connectBackend uses the local backend endpoint when no browser config is p
 
   physics.connectBackend();
 
-  assert.equal(createdUrl, 'http://localhost:8080/ws');
+  assert.equal(createdUrl, 'ws://localhost:8080/ws');
 
   if (previousWebSocket === undefined) {
     delete globalThis.WebSocket;
   } else {
     globalThis.WebSocket = previousWebSocket;
   }
+});
+
+test('connectBackend uses the current frontend host when a browser proxy is available', () => {
+  const physics = new GamePhysics(Config);
+  const previousWebSocket = globalThis.WebSocket;
+  const previousLocation = globalThis.location;
+  let createdUrl = null;
+
+  class FakeWebSocket {
+    constructor(url) {
+      createdUrl = url;
+    }
+
+    addEventListener() {}
+  }
+
+  globalThis.WebSocket = FakeWebSocket;
+  globalThis.location = { protocol: 'http:', host: 'localhost:3001' };
+
+  physics.connectBackend();
+
+  assert.equal(createdUrl, 'ws://localhost:3001/ws');
+
+  if (previousWebSocket === undefined) delete globalThis.WebSocket;
+  else globalThis.WebSocket = previousWebSocket;
+
+  if (previousLocation === undefined) delete globalThis.location;
+  else globalThis.location = previousLocation;
 });
 
 test('sendImpact emits a structured impact payload when the backend socket is ready', () => {
@@ -102,7 +141,7 @@ test('sendImpact emits a structured impact payload when the backend socket is re
   }
 });
 
-test('high-level game event helpers send the documented backend message types', () => {
+test('sendMessage sends the documented high-level game event types', () => {
   const physics = new GamePhysics(Config);
   const sentPayloads = [];
   const previousWebSocket = globalThis.WebSocket;
@@ -118,12 +157,12 @@ test('high-level game event helpers send the documented backend message types', 
     }
   };
 
-  assert.equal(physics.startGame(), true);
-  assert.equal(physics.toggleBossFight(), true);
-  assert.equal(physics.triggerPlayerDamageTest(), true);
-  assert.equal(physics.triggerBallLost(), true);
-  assert.equal(physics.saveGame(1), true);
-  assert.equal(physics.loadGame(2), true);
+  assert.equal(physics.sendMessage('start_game'), true);
+  assert.equal(physics.sendMessage('boss_fight_toggled'), true);
+  assert.equal(physics.sendMessage('player_damage_test'), true);
+  assert.equal(physics.sendMessage('ball_lost'), true);
+  assert.equal(physics.sendMessage('save_game', { slot: 1 }), true);
+  assert.equal(physics.sendMessage('load_game', { slot: 2 }), true);
 
   assert.deepEqual(sentPayloads.map((message) => message.type), [
     'start_game',
@@ -303,7 +342,6 @@ test('handleCollisionEvents can report a ramp-side collision while delegating th
   // reportContactImpacts skips balls intentionally — only non-ball objects trigger sendImpact
   assert.deepEqual(calls, [
     'ramp:collision',
-    'ramp:force:10-11',
     'impact:launching-ramp-right-rail'
   ]);
 });
@@ -340,6 +378,9 @@ test('step only verifies ramp traversal after a collision is detected', () => {
     calls.push('score-check');
   };
 
+  physics.checkLaunchingRampHeight = function () {};
+  physics.checkBallOutOfBounds = function () {};
+
   physics.step();
 
   assert.deepEqual(calls, [
@@ -350,7 +391,7 @@ test('step only verifies ramp traversal after a collision is detected', () => {
 });
 
 test('detectScoreZoneEntries emits more specific target and star impacts when the ball enters configured zones', () => {
-  withConfigPatch('scoreZones', {
+  withPositioningPatch('scoreZones', {
     instances: [
       {
         id: 'target-left-centre',
@@ -383,7 +424,7 @@ test('detectScoreZoneEntries emits more specific target and star impacts when th
       }
     };
 
-    physics.objects = [ball];
+    physics.registerObjects([ball]);
     physics.detectScoreZoneEntries();
 
     assert.deepEqual(sent, ['target:target-left-centre']);
@@ -399,7 +440,7 @@ test('detectScoreZoneEntries emits more specific target and star impacts when th
 });
 
 test('detectScoreZoneEntries does not spam the same zone until the ball exits and re-enters', () => {
-  withConfigPatch('scoreZones', {
+  withPositioningPatch('scoreZones', {
     instances: [
       {
         id: 'loop-left',
@@ -426,7 +467,7 @@ test('detectScoreZoneEntries does not spam the same zone until the ball exits an
       }
     };
 
-    physics.objects = [ball];
+    physics.registerObjects([ball]);
 
     physics.detectScoreZoneEntries();
     physics.detectScoreZoneEntries();
@@ -443,7 +484,7 @@ test('detectScoreZoneEntries does not spam the same zone until the ball exits an
 });
 
 test('detectRampTraversal emits ramp-main-perfect when the ball crosses the ramp without wall bounce', () => {
-  withConfigPatch('ramps', {
+  withPositioningPatch('ramps', {
     instances: [
       {
         entryZone: {
@@ -477,19 +518,19 @@ test('detectRampTraversal emits ramp-main-perfect when the ball crosses the ramp
       }
     };
 
-    physics.objects = [ball];
+    physics.registerObjects([ball]);
 
     physics.detectRampTraversal();
     ball.rigidBody.translation = () => ({ x: 0, y: 0, z: 100 });
     physics.activeRampZones.clear();
     physics.detectRampTraversal();
 
-    assert.deepEqual(sent, ['launching_ramp:ramp-main-perfect']);
+    assert.deepEqual(sent, ['launching-ramp:ramp-main-perfect']);
   });
 });
 
-test('detectRampTraversal emits ramp-main-simple after a wall bounce during traversal', () => {
-  withConfigPatch('ramps', {
+test('detectRampTraversal emits ramp-main-simple when the traversal records a wall bounce', () => {
+  withPositioningPatch('ramps', {
     instances: [
       {
         entryZone: {
@@ -523,13 +564,13 @@ test('detectRampTraversal emits ramp-main-simple after a wall bounce during trav
       }
     };
 
-    physics.objects = [ball];
+    physics.registerObjects([ball]);
 
     physics.detectRampTraversal();
-    physics.markRampBounce([{ objectType: 'wall' }, { objectType: 'ball' }]);
+    physics.rampTraversal.hasWallBounce = true;
     ball.rigidBody.translation = () => ({ x: 0, y: 0, z: 100 });
     physics.detectRampTraversal();
 
-    assert.deepEqual(sent, ['launching_ramp:ramp-main-simple']);
+    assert.deepEqual(sent, ['launching-ramp:ramp-main-simple']);
   });
 });


### PR DESCRIPTION
## Résumé

Cette PR corrige la connexion WebSocket au backend en développement local et harmonise les commandes clavier avec les boutons du flipper physique.

## Connexion backend

- ajout d’un proxy Nginx local de `/ws` vers `backend:8080/ws` ;
- installation de cette configuration dans les trois frontends Docker ;
- conservation du fonctionnement basé sur l’hôte courant pour être compatible localement et sur Fliphetic ;
- correction et ajout des tests associés.

## Commandes

- flipper gauche : `Q` / `W` ;
- flipper droit : `D` / `C` ;
- plunger : `Espace` ;
- boss : `B` ;
- perte de HP : `H` ;
- perte de balle : `L` ;
- mise à jour du mapping ESP32, de l’écran de lancement et de la documentation.

## Validation

- 28 tests frontend réussis ;
- lint réussi ;
- `docker compose config -q` réussi ;
- connexion WebSocket locale validée.

Closes #188
