### PR TITLE
Déploiement : tester l’application depuis develop

### DIFF
--- a/fliphetic.toml
+++ b/fliphetic.toml
@@ -6,7 +6,7 @@ description = "Flipper virtuel avec Playfield, Backglass, DMD et contrôleur ESP
 
 [deploy]
 strategy = "branch"
-ref      = "feature/lancement-automatique-flipper-dmd-95"
+ref      = "develop"
 
 [screens]
 playfield = { service = "app", port = 80, path = "/playfield/?cabinet=1" }


### PR DESCRIPTION
## Résumé

- remplace l’ancienne référence de déploiement par `develop` ;
- permet à Fliphetic de charger la version actuellement intégrée dans `develop` ;
- évite de continuer à tester une ancienne branche de fonctionnalité.

## Validation

- 6 tests de déploiement réussis ;
- lint réussi ;
- configuration Docker Compose valide.